### PR TITLE
Fix undo not removing life on Anki 2.1

### DIFF
--- a/src/lifedrain/lifedrain.py
+++ b/src/lifedrain/lifedrain.py
@@ -993,6 +993,7 @@ addHook('afterStateChange', afterStateChange)
 addHook('showQuestion', showQuestion)
 addHook('showAnswer', showAnswer)
 addHook('reset', undo)
+addHook('undoState', lambda on: undo() if not on else None)  # After an undo, the state gets off
 addHook('leech', leech)
 addHook('LifeDrain.recover', recover)
 

--- a/src/lifedrain/lifedrain.py
+++ b/src/lifedrain/lifedrain.py
@@ -993,7 +993,7 @@ addHook('afterStateChange', afterStateChange)
 addHook('showQuestion', showQuestion)
 addHook('showAnswer', showAnswer)
 addHook('reset', undo)
-addHook('undoState', lambda on: undo() if not on else None)  # After an undo, the state gets off
+addHook('revertedCard', lambda cid: undo())
 addHook('leech', leech)
 addHook('LifeDrain.recover', recover)
 


### PR DESCRIPTION
Fixes #33 

The implementation for Anki 2.0 does not work for Anki 2.1. This PR fixes it.