### PR TITLE
Automatically set bar's background color

### DIFF
--- a/lifedrain/deck_manager.py
+++ b/lifedrain/deck_manager.py
@@ -130,7 +130,6 @@ class DeckManager(object):
         self._progress_bar.dock_at(self._get_conf('barPosition'))
         progress_bar_style = {
             'height': self._get_conf('barHeight'),
-            'backgroundColor': self._get_conf('barBgColor'),
             'foregroundColor': self._get_conf('barFgColor'),
             'borderRadius': self._get_conf('barBorderRadius'),
             'text': self._get_conf('barText'),

--- a/lifedrain/defaults.py
+++ b/lifedrain/defaults.py
@@ -34,7 +34,6 @@ DEFAULTS = {
     'damage': 5,
     'barPosition': POSITION_OPTIONS.index('Bottom'),
     'barHeight': 15,
-    'barBgColor': '#f3f3f2',
     'barFgColor': '#489ef6',
     'barBorderRadius': 0,
     'barText': 0,

--- a/lifedrain/progress_bar.py
+++ b/lifedrain/progress_bar.py
@@ -98,14 +98,8 @@ class ProgressBar(object):
             .replace(' ', '').lower()
         if custom_style != 'default':
             palette = self._qt.QPalette()
-            palette.setColor(self._qt.QPalette.Base,
-                             self._qt.QColor(options['backgroundColor']))
             palette.setColor(self._qt.QPalette.Highlight,
                              self._qt.QColor(options['foregroundColor']))
-            palette.setColor(self._qt.QPalette.Button,
-                             self._qt.QColor(options['backgroundColor']))
-            palette.setColor(self._qt.QPalette.Window,
-                             self._qt.QColor(options['backgroundColor']))
 
             self._qprogressbar.setStyle(
                 self._qt.QStyleFactory.create(custom_style))
@@ -119,7 +113,6 @@ class ProgressBar(object):
             self._qprogressbar.setStyleSheet('''
                 QProgressBar {
                     text-align:center;
-                    background-color: %s;
                     border-radius: %dpx;
                     max-height: %spx;
                     color: %s;
@@ -129,9 +122,9 @@ class ProgressBar(object):
                     margin: 0px;
                     border-radius: %dpx;
                 }
-                ''' % (options['backgroundColor'], options['borderRadius'],
-                       options['height'], options['textColor'],
-                       options['foregroundColor'], options['borderRadius']))
+                ''' % (options['borderRadius'], options['height'],
+                       options['textColor'], options['foregroundColor'],
+                       options['borderRadius']))
 
     def dock_at(self, position):
         """Docks the bar at the specified position in the Anki window.

--- a/lifedrain/settings.py
+++ b/lifedrain/settings.py
@@ -46,8 +46,7 @@ class Settings(object):
         self._create_combo_box('textList', 'Text',
                                map(itemgetter('text'), TEXT_FORMAT))
         self._create_combo_box('styleList', 'Style', STYLE_OPTIONS)
-        self._create_color_select('bgColor', 'Background color')
-        self._create_color_select('fgColor', 'Foreground color')
+        self._create_color_select('fgColor', 'Bar color')
         self._create_color_select('textColor', 'Text color')
         self._fill_remaining_space()
         form.tabWidget.addTab(form.lifedrain_widget, 'Life Drain')
@@ -107,11 +106,6 @@ class Settings(object):
 
         form.positionList.setCurrentIndex(self._get_conf('barPosition'))
         form.heightInput.setValue(self._get_conf('barHeight'))
-        form.bgColorDialog.setCurrentColor(
-            self._qt.QColor(self._get_conf('barBgColor')))
-        form.bgColorPreview.setStyleSheet(
-            'QLabel { background-color: %s; }' %
-            form.bgColorDialog.currentColor().name())
         form.fgColorDialog.setCurrentColor(
             self._qt.QColor(self._get_conf('barFgColor')))
         form.fgColorPreview.setStyleSheet(
@@ -140,7 +134,6 @@ class Settings(object):
 
         conf['barPosition'] = form.positionList.currentIndex()
         conf['barHeight'] = form.heightInput.value()
-        conf['barBgColor'] = form.bgColorDialog.currentColor().name()
         conf['barFgColor'] = form.fgColorDialog.currentColor().name()
         conf['barBorderRadius'] = form.borderRadiusInput.value()
         conf['barText'] = form.textList.currentIndex()
@@ -148,6 +141,7 @@ class Settings(object):
         conf['barStyle'] = form.styleList.currentIndex()
         conf['stopOnAnswer'] = form.stopOnAnswer.isChecked()
         conf['disable'] = form.disableAddon.isChecked()
+        conf.pop('barBgColor', None)
         return conf
 
     def deck_settings_load(self, settings, current_life):


### PR DESCRIPTION
Remove its setting and all places that were using it. This makes Qt set the background automatically.

My guess is that most users just set a background color that is similar to the window's color. I do that. So lets make Qt do this automatically for us.
With this, even if you toggle Night Mode, the bar's background color will be automatically adjusted.
The add-on will slightly lose customizability, but it will be easier to setup.