### PR TITLE
Move deck settings to a new window

### DIFF
--- a/lifedrain/deck_manager.py
+++ b/lifedrain/deck_manager.py
@@ -130,6 +130,7 @@ class DeckManager(object):
             old_conf.pop('currentValue', None)
             conf['lifedrain'] = lifedrain_conf
             self._main_window.col.decks.save(conf)
+            self._main_window.col.decks.save(old_conf)
 
         self._conf = lifedrain_conf
         self._bar_info[deck_id] = {

--- a/lifedrain/deck_manager.py
+++ b/lifedrain/deck_manager.py
@@ -93,7 +93,7 @@ class DeckManager(object):
         if not increment:
             multiplier = -1
         if value is None:
-            if damage is not None:
+            if damage and self._bar_info[deck_id]['damageValue'] is not None:
                 multiplier = -1
                 value = self._bar_info[deck_id]['damageValue']
             else:

--- a/lifedrain/deck_manager.py
+++ b/lifedrain/deck_manager.py
@@ -62,21 +62,21 @@ class DeckManager(object):
             self._add_deck(deck_id)
         return self._bar_info[deck_id]
 
-    def set_deck_conf(self, deck_id, conf):
+    def set_deck_conf(self, conf):
         """Updates a deck's current settings and state.
 
         Args:
             deck_id: The ID of the deck.
             conf: A dictionary with the deck's configuration and state.
         """
-        current_value = conf['currentValue']
-        if current_value > conf['maxLife']:
-            current_value = conf['maxLife']
+        current_value = conf['lifedrain']['currentValue']
+        if current_value > conf['lifedrain']['maxLife']:
+            current_value = conf['lifedrain']['maxLife']
 
-        self._bar_info[deck_id]['maxValue'] = conf['maxLife']
-        self._bar_info[deck_id]['recoverValue'] = conf['recover']
-        self._bar_info[deck_id]['enableDamageValue'] = conf['enableDamage']
-        self._bar_info[deck_id]['damageValue'] = conf['damage']
+        deck_id = conf['id']
+        self._bar_info[deck_id]['maxValue'] = conf['lifedrain']['maxLife']
+        self._bar_info[deck_id]['recoverValue'] = conf['lifedrain']['recover']
+        self._bar_info[deck_id]['damageValue'] = conf['lifedrain']['damage']
         self._bar_info[deck_id]['currentValue'] = current_value
 
     def recover_life(self, increment=True, value=None, damage=False):
@@ -93,7 +93,7 @@ class DeckManager(object):
         if not increment:
             multiplier = -1
         if value is None:
-            if damage and self._bar_info[deck_id]['enableDamageValue']:
+            if damage is not None:
                 multiplier = -1
                 value = self._bar_info[deck_id]['damageValue']
             else:
@@ -115,12 +115,27 @@ class DeckManager(object):
         Args:
             deck_id: The ID of the deck.
         """
-        self._conf = self._main_window.col.decks.confForDid(deck_id)
+        conf = self._main_window.col.decks.current()
+        lifedrain_conf = conf.get('lifedrain')
+        if not lifedrain_conf:
+            old_conf = self._main_window.col.decks.confForDid(deck_id)
+            dmg_value = old_conf.pop('damage', DEFAULTS['damage'])
+            dmg_enable = old_conf.pop('enableDamage', False)
+            damage = dmg_value if dmg_enable else None
+            lifedrain_conf = {
+                'maxLife': old_conf.pop('maxLife', DEFAULTS['maxLife']),
+                'recover': old_conf.pop('recover', DEFAULTS['recover']),
+                'damage': damage
+            }
+            old_conf.pop('currentValue', None)
+            conf['lifedrain'] = lifedrain_conf
+            self._main_window.col.decks.save(conf)
+
+        self._conf = lifedrain_conf
         self._bar_info[deck_id] = {
             'maxValue': self._get_conf('maxLife'),
             'currentValue': self._get_conf('maxLife'),
             'recoverValue': self._get_conf('recover'),
-            'enableDamageValue': self._get_conf('enableDamage'),
             'damageValue': self._get_conf('damage')
         }
 

--- a/lifedrain/defaults.py
+++ b/lifedrain/defaults.py
@@ -30,8 +30,7 @@ TEXT_FORMAT = [{
 DEFAULTS = {
     'maxLife': 120,
     'recover': 5,
-    'enableDamage': False,
-    'damage': 5,
+    'damage': None,
     'barPosition': POSITION_OPTIONS.index('Bottom'),
     'barHeight': 15,
     'barFgColor': '#489ef6',

--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -82,6 +82,11 @@ class Lifedrain(object):
         if conf['disable'] is True:
             self.deck_manager.bar_visible(False)
 
+    def deck_settings(self):
+        """Opens a dialog with the Deck Settings."""
+        deck = self.main_window.col.decks.current()
+        self._settings.deck_settings(deck['name'])
+
     def deck_settings_load(self, settings):
         """Loads Life Drain deck settings into the Deck Settings dialog.
 

--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -85,11 +85,15 @@ class Lifedrain(object):
 
         life = lifedrain_conf['currentValue']
         set_deck_conf = self.deck_manager.set_deck_conf
+
+        drain_enabled = self._timer.isActive()
+        self.toggle_drain(False)
         self._settings.deck_settings(deck, life, set_deck_conf, old_conf)
+        self.toggle_drain(drain_enabled)
 
         self.main_window.col.decks.save(deck)
         self.main_window.col.decks.save(old_conf)
-        self.screen_change(self._state)
+        self.deck_manager.set_deck(deck['id'])
 
     @must_be_enabled
     def toggle_drain(self, enable=None):

--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -85,7 +85,9 @@ class Lifedrain(object):
     def deck_settings(self):
         """Opens a dialog with the Deck Settings."""
         deck = self.main_window.col.decks.current()
-        self._settings.deck_settings(deck['name'])
+        lifedrain_conf = self.deck_manager.get_deck_conf(deck['id'])
+        conf = self.main_window.col.decks.confForDid(deck['id'])
+        self._settings.deck_settings(conf, lifedrain_conf['currentValue'])
 
     def deck_settings_load(self, settings):
         """Loads Life Drain deck settings into the Deck Settings dialog.

--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -20,8 +20,6 @@ class Lifedrain(object):
         main_window: A reference to the Anki's main window.
         status: A dictionary that keeps track the events on Anki.
         preferences_ui: Function that generates the Global Settings dialog.
-        deck_settings_ui: Function that generates the Deck Settings dialog.
-        custom_deck_settings_ui: Function that generates the Filtered Deck
         Settings dialog.
     """
 
@@ -34,11 +32,10 @@ class Lifedrain(object):
         'screen': None,
     }
     preferences_ui = None
-    deck_settings_ui = None
-    custom_deck_settings_ui = None
 
     _settings = None
     _timer = None
+    _state = None
 
     def __init__(self, make_timer, mw, qt):
         """Initializes DeckManager and Settings, and add-on initial setup.
@@ -56,8 +53,6 @@ class Lifedrain(object):
         self._timer.stop()
 
         self.preferences_ui = self._settings.preferences_ui
-        self.deck_settings_ui = self._settings.deck_settings_ui
-        self.custom_deck_settings_ui = self._settings.custom_deck_settings_ui
 
     def preferences_load(self, pref):
         """Loads Life Drain global settings into the Global Settings dialog.
@@ -86,31 +81,14 @@ class Lifedrain(object):
         """Opens a dialog with the Deck Settings."""
         deck = self.main_window.col.decks.current()
         lifedrain_conf = self.deck_manager.get_deck_conf(deck['id'])
-        conf = self.main_window.col.decks.confForDid(deck['id'])
-        self._settings.deck_settings(conf, lifedrain_conf['currentValue'])
+        old_conf = self.main_window.col.decks.confForDid(deck['id'])
 
-    def deck_settings_load(self, settings):
-        """Loads Life Drain deck settings into the Deck Settings dialog.
+        life = lifedrain_conf['currentValue']
+        set_deck_conf = self.deck_manager.set_deck_conf
+        self._settings.deck_settings(deck, life, set_deck_conf, old_conf)
 
-        Args:
-            settings: The instance of the Deck Settings dialog.
-        """
-        deck_id = settings.deck['id']
-        self._settings.deck_settings_load(
-            settings,
-            self.deck_manager.get_deck_conf(deck_id)['currentValue'])
-        self.toggle_drain(False)
-
-    def deck_settings_save(self, settings):
-        """Saves Life Drain deck settings.
-
-        Args:
-            settings: The instance of the Deck Settings dialog.
-        """
-        deck_conf = self._settings.deck_settings_save(settings)
-        self.deck_manager.set_deck_conf(settings.deck['id'], deck_conf)
-        self.status['card_new_state'] = True
-        self.status['reviewed'] = False
+        self.main_window.col.decks.save(deck)
+        self.screen_change(self._state)
 
     @must_be_enabled
     def toggle_drain(self, enable=None):
@@ -131,6 +109,7 @@ class Lifedrain(object):
         Args:
             state: The name of the current screen.
         """
+        self._state = state
         if state != 'review':
             self.toggle_drain(False)
 

--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -88,6 +88,7 @@ class Lifedrain(object):
         self._settings.deck_settings(deck, life, set_deck_conf, old_conf)
 
         self.main_window.col.decks.save(deck)
+        self.main_window.col.decks.save(old_conf)
         self.screen_change(self._state)
 
     @must_be_enabled

--- a/lifedrain/main.py
+++ b/lifedrain/main.py
@@ -7,8 +7,6 @@ from anki.collection import _Collection
 from anki.hooks import addHook, wrap
 from anki.sched import Scheduler
 from aqt import forms, mw, qt
-from aqt.deckconf import DeckConf
-from aqt.dyndeckconf import DeckConf as FiltDeckConf
 from aqt.editcurrent import EditCurrent
 from aqt.preferences import Preferences
 from aqt.progress import ProgressManager
@@ -47,27 +45,6 @@ def setup_user_interface(lifedrain):
     Preferences.accept = wrap(
         Preferences.accept, lambda *args: lifedrain.preferences_save(args[0]),
         'before')
-
-    # Deck Settings
-    forms.dconf.Ui_Dialog.setupUi = wrap(
-        forms.dconf.Ui_Dialog.setupUi,
-        lambda *args: lifedrain.deck_settings_ui(args[0]))
-    DeckConf.loadConf = wrap(
-        DeckConf.loadConf, lambda *args: lifedrain.deck_settings_load(args[0]))
-    DeckConf.saveConf = wrap(
-        DeckConf.saveConf, lambda *args: lifedrain.deck_settings_save(args[0]),
-        'before')
-
-    # Filtered Deck Settings
-    forms.dyndconf.Ui_Dialog.setupUi = wrap(
-        forms.dyndconf.Ui_Dialog.setupUi,
-        lambda *args: lifedrain.custom_deck_settings_ui(args[0]))
-    FiltDeckConf.loadConf = wrap(
-        FiltDeckConf.loadConf,
-        lambda *args: lifedrain.deck_settings_load(args[0]))
-    FiltDeckConf.saveConf = wrap(
-        FiltDeckConf.saveConf,
-        lambda *args: lifedrain.deck_settings_save(args[0]), 'before')
 
 
 def setup_shortcuts(lifedrain):

--- a/lifedrain/main.py
+++ b/lifedrain/main.py
@@ -53,12 +53,15 @@ def setup_shortcuts(lifedrain):
     Args:
         lifedrain: A Lifedrain instance.
     """
-    toggle_drain_shortcut = tuple(['p', lifedrain.toggle_drain])
-    addHook('reviewStateShortcuts',
-            lambda shortcuts: shortcuts.append(toggle_drain_shortcut))
-    deck_settings_shortcut = tuple(['l', lifedrain.deck_settings])
-    addHook('overviewStateShortcuts',
-            lambda shortcuts: shortcuts.append(deck_settings_shortcut))
+    def review(shortcuts):
+        shortcuts.append(tuple(['p', lifedrain.toggle_drain]))
+        shortcuts.append(tuple(['l', lifedrain.deck_settings]))
+
+    def overview(shortcuts):
+        shortcuts.append(tuple(['l', lifedrain.deck_settings]))
+
+    addHook('reviewStateShortcuts', review)
+    addHook('overviewStateShortcuts', overview)
 
 
 def setup_hooks(lifedrain):

--- a/lifedrain/main.py
+++ b/lifedrain/main.py
@@ -5,6 +5,7 @@ See the LICENCE file in the repository root for full licence text.
 
 from anki.collection import _Collection
 from anki.hooks import addHook, wrap
+from anki.lang import _
 from anki.sched import Scheduler
 from aqt import forms, mw, qt
 from aqt.editcurrent import EditCurrent
@@ -87,7 +88,7 @@ def setup_hooks(lifedrain):
 
             def update_buf(buf):
                 attribute_list = [
-                    'title="Shortcut key: L"',
+                    'title="{}"'.format(_('Shortcut key: %s') % 'L'),
                     'onclick="pycmd(\'lifedrain\')"']
                 attributes = ' '.join(attribute_list)
                 text = 'Life Drain'

--- a/lifedrain/main.py
+++ b/lifedrain/main.py
@@ -79,6 +79,9 @@ def setup_shortcuts(lifedrain):
     toggle_drain_shortcut = tuple(['p', lifedrain.toggle_drain])
     addHook('reviewStateShortcuts',
             lambda shortcuts: shortcuts.append(toggle_drain_shortcut))
+    deck_settings_shortcut = tuple(['l', lifedrain.deck_settings])
+    addHook('overviewStateShortcuts',
+            lambda shortcuts: shortcuts.append(deck_settings_shortcut))
 
 
 def setup_hooks(lifedrain):

--- a/lifedrain/settings.py
+++ b/lifedrain/settings.py
@@ -79,7 +79,7 @@ class Settings(object):
         form.maxLifeInput.setValue(self._get_conf('maxLife'))
         form.recoverInput.setValue(self._get_conf('recover'))
         damage = self._get_conf('damage')
-        form.enableDamageInput.setChecked(damage is None)
+        form.enableDamageInput.setChecked(damage is not None)
         form.damageInput.setValue(damage if damage else 5)
         form.currentValueInput.setValue(life)
 
@@ -213,22 +213,6 @@ class Settings(object):
         if 'barBgColor' in conf:
             del conf['barBgColor']
         return conf
-
-    def deck_settings_load(self, settings, current_life):
-        """Loads Life Drain deck settings into the form.
-
-        Args:
-            settings: The instance of the Deck Settings dialog.
-            current_life: The current amount of life.
-        """
-        self._conf = settings.mw.col.decks.confForDid(settings.deck['id'])
-        form = settings.form
-
-        form.maxLifeInput.setValue(self._get_conf('maxLife'))
-        form.recoverInput.setValue(self._get_conf('recover'))
-        form.enableDamageInput.setChecked(self._get_conf('enableDamage'))
-        form.damageInput.setValue(self._get_conf('damage'))
-        form.currentValueInput.setValue(current_life)
 
     @staticmethod
     def deck_settings_save(form, conf):

--- a/lifedrain/settings.py
+++ b/lifedrain/settings.py
@@ -50,15 +50,23 @@ class Settings(object):
         self._fill_remaining_space()
         form.tabWidget.addTab(form.lifedrain_widget, 'Life Drain')
 
-    def deck_settings(self, deck_name):
+    def deck_settings(self, conf, current_life):
         """Opens a dialog with the Deck Settings."""
+        self._conf = conf
         settings_dialog = self._qt.QDialog()
 
-        window_title = 'Life Drain options for {}'.format(deck_name)
+        window_title = 'Life Drain options for {}'.format(conf['name'])
         settings_dialog.setWindowTitle(window_title)
 
         layout = self._qt.QGridLayout(settings_dialog)
         self.build_deck_settings_form(settings_dialog, layout)
+
+        form = settings_dialog
+        form.maxLifeInput.setValue(self._get_conf('maxLife'))
+        form.recoverInput.setValue(self._get_conf('recover'))
+        form.enableDamageInput.setChecked(self._get_conf('enableDamage'))
+        form.damageInput.setValue(self._get_conf('damage'))
+        form.currentValueInput.setValue(current_life)
 
         button_box = self._qt.QDialogButtonBox(
             self._qt.QDialogButtonBox.Ok |

--- a/lifedrain/settings.py
+++ b/lifedrain/settings.py
@@ -51,6 +51,41 @@ class Settings(object):
         self._fill_remaining_space()
         form.tabWidget.addTab(form.lifedrain_widget, 'Life Drain')
 
+    def deck_settings(self, deck_name):
+        """Opens a dialog with the Deck Settings."""
+        settings_dialog = self._qt.QDialog()
+
+        window_title = 'Life Drain options for {}'.format(deck_name)
+        settings_dialog.setWindowTitle(window_title)
+
+        layout = self._qt.QGridLayout(settings_dialog)
+        self.build_deck_settings_form(settings_dialog, layout)
+
+        settings_dialog.exec()
+
+    def build_deck_settings_form(self, form, layout):
+        """Appends a Life Drain tab to Deck Settings dialog.
+
+        Args:
+            form: The form instance of the Global Settings dialog.
+        """
+        self._form = form
+        self._row = 0
+
+        form.lifedrain_widget = self._qt.QWidget()
+        form.lifedrain_layout = layout
+        self._create_label(
+            'The <b>maximum life</b> is the time in seconds for the life bar '
+            'go from full to empty.\n<b>Recover</b> is the time in seconds '
+            'that is recovered after answering a card. <b>Damage</b> is the '
+            'life lost when a card is answered with \'Again\'.')
+        self._create_spin_box('maxLifeInput', 'Maximum life', [1, 10000])
+        self._create_spin_box('recoverInput', 'Recover', [0, 1000])
+        self._create_check_box('enableDamageInput', 'Enable damage')
+        self._create_spin_box('damageInput', 'Damage', [-1000, 1000])
+        self._create_spin_box('currentValueInput', 'Current life', [0, 10000])
+        self._fill_remaining_space()
+
     def deck_settings_ui(self, form):
         """Appends a Life Drain tab to Deck Settings dialog.
 

--- a/lifedrain/settings.py
+++ b/lifedrain/settings.py
@@ -60,6 +60,12 @@ class Settings(object):
         layout = self._qt.QGridLayout(settings_dialog)
         self.build_deck_settings_form(settings_dialog, layout)
 
+        button_box = self._qt.QDialogButtonBox(
+            self._qt.QDialogButtonBox.Ok |
+            self._qt.QDialogButtonBox.Cancel
+        )
+        layout.addWidget(button_box, self._row, 0, 1, 4)
+
         settings_dialog.exec()
 
     def build_deck_settings_form(self, form, layout):


### PR DESCRIPTION
Move Life Drain's deck settings to a new window.

The biggest advantage for this will be for Filtered Decks, which for now you have to rebuild the deck to change the Life Drain options. So it partially resolves the issue #52 .

It will also improve the code quality. Now I have to maintain two deck option windows: one for normal decks and one for filtered decks. With a separated window, the configuration will be centralized. Adding new deck options will be easier.