### PR TITLE
Fix exception raised when closing preferences

### DIFF
--- a/lifedrain/settings.py
+++ b/lifedrain/settings.py
@@ -140,7 +140,8 @@ class Settings(object):
         conf['barStyle'] = form.styleList.currentIndex()
         conf['stopOnAnswer'] = form.stopOnAnswer.isChecked()
         conf['disable'] = not form.enableAddon.isChecked()
-        conf.pop('barBgColor', None)
+        if 'barBgColor' in conf:
+            del conf['barBgColor']
         return conf
 
     def deck_settings_load(self, settings, current_life):


### PR DESCRIPTION
Regression from #53 .
I was unable to close Anki in the usual way. Had to kill the process.

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/aqt/preferences.py", line 48, in reject
    self.accept()
  File "<decorator-gen-10>", line 2, in accept
  File "/usr/lib/python3.8/site-packages/anki/hooks.py", line 638, in decorator_wrapper
    return repl(*args, **kwargs)
  File "/usr/lib/python3.8/site-packages/anki/hooks.py", line 632, in repl
    new(*args, **kwargs)
  File "/home/mateus/.local/share/Anki2/addons21/lifedrain/main.py", line 48, in <lambda>
    Preferences.accept, lambda *args: lifedrain.preferences_save(args[0]),
  File "/home/mateus/.local/share/Anki2/addons21/lifedrain/lifedrain.py", line 77, in preferences_save
    conf = self._settings.preferences_save(pref)
  File "/home/mateus/.local/share/Anki2/addons21/lifedrain/settings.py", line 183, in preferences_save
    conf.pop('barBgColor', None)
AttributeError: 'ConfigManager' object has no attribute 'pop'
```