### PR TITLE
Deprecate old forms for deck settings

### DIFF
--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -34,6 +34,11 @@ class Lifedrain:
     }
     preferences_ui = None
 
+    # deprecated
+    deck_settings_ui = None
+    custom_deck_settings_ui = None
+    # end-of-deprecated
+
     _global_settings = None
     _deck_settings = None
     _timer = None
@@ -58,6 +63,11 @@ class Lifedrain:
         self._timer.stop()
 
         self.preferences_ui = self._global_settings.generate_form
+        # deprecated
+        self.deck_settings_ui = self._deck_settings.old_generate_deck_form
+        self.custom_deck_settings_ui = \
+            self._deck_settings.old_generate_custom_deck_form
+        # end-of-deprecated
 
     def preferences_load(self, pref):
         """Loads Life Drain global settings into the Global Settings dialog.
@@ -81,6 +91,27 @@ class Lifedrain:
 
         if conf['disable'] is True:
             self.deck_manager.bar_visible(False)
+
+    # Deprecated method
+    def deck_settings_load(self, settings):
+        """Loads Life Drain deck settings into the Deck Settings dialog.
+        Args:
+            settings: The instance of the Deck Settings dialog.
+        """
+        self._deck_settings.old_load_form_data(
+            settings, self.deck_manager.get_current_life())
+        self.toggle_drain(False)
+
+    # Deprecated method
+    def deck_settings_save(self, settings):
+        """Saves Life Drain deck settings.
+        Args:
+            settings: The instance of the Deck Settings dialog.
+        """
+        set_deck_conf = self.deck_manager.set_deck_conf
+        self._deck_settings.old_save_form_data(settings, set_deck_conf)
+        self.status['card_new_state'] = True
+        self.status['reviewed'] = False
 
     def deck_settings(self):
         """Opens a dialog with the Deck Settings."""

--- a/lifedrain/main.py
+++ b/lifedrain/main.py
@@ -11,6 +11,11 @@ from aqt.progress import ProgressManager
 from aqt.reviewer import Reviewer
 from aqt.toolbar import BottomBar
 
+# deprecated
+from aqt.deckconf import DeckConf
+from aqt.dyndeckconf import DeckConf as FiltDeckConf
+# end-of-deprecated
+
 from anki.collection import _Collection
 from anki.hooks import addHook, wrap
 from anki.lang import _
@@ -133,3 +138,26 @@ def setup_hooks(lifedrain):
         Reviewer._answerCard,  # pylint: disable=protected-access
         lambda *args: lifedrain.status.update({'review_response': args[1]}),
         'before')
+
+    # deprecated
+    # Deck Settings
+    forms.dconf.Ui_Dialog.setupUi = wrap(
+        forms.dconf.Ui_Dialog.setupUi,
+        lambda *args: lifedrain.deck_settings_ui(args[0]))
+    DeckConf.loadConf = wrap(
+        DeckConf.loadConf, lambda *args: lifedrain.deck_settings_load(args[0]))
+    DeckConf.saveConf = wrap(
+        DeckConf.saveConf, lambda *args: lifedrain.deck_settings_save(args[0]),
+        'before')
+
+    # Filtered Deck Settings
+    forms.dyndconf.Ui_Dialog.setupUi = wrap(
+        forms.dyndconf.Ui_Dialog.setupUi,
+        lambda *args: lifedrain.custom_deck_settings_ui(args[0]))
+    FiltDeckConf.loadConf = wrap(
+        FiltDeckConf.loadConf,
+        lambda *args: lifedrain.deck_settings_load(args[0]))
+    FiltDeckConf.saveConf = wrap(
+        FiltDeckConf.saveConf,
+        lambda *args: lifedrain.deck_settings_save(args[0]), 'before')
+    # end-of-deprecated

--- a/lifedrain/settings.py
+++ b/lifedrain/settings.py
@@ -19,7 +19,7 @@ class Form:
     def __init__(self, qt):
         self._qt = qt
 
-    def label(self, text, color=None):
+    def label(self, text, color=None, minw=None, minh=None):
         """Creates a label in the current row of the form.
 
         Args:
@@ -28,6 +28,8 @@ class Form:
         """
         label = self._qt.QLabel(text)
         label.setWordWrap(True)
+        if minw and minh:
+            label.setMinimumSize(minw, minh)
         self._form.lifedrain_layout.addWidget(label, self._row, 0, 1, 4)
         if color:
             label.setStyleSheet('color: {}'.format(color))
@@ -300,10 +302,10 @@ class DeckSettings(Form):
         form.lifedrain_widget = self._qt.QWidget()
         form.lifedrain_layout = self._qt.QGridLayout(form.lifedrain_widget)
         self.label(
-            'The <b>maximum life</b> is the time in seconds for the life bar '
-            'go from full to empty.\n<b>Recover</b> is the time in seconds '
-            'that is recovered after answering a card. <b>Damage</b> is the '
-            'life lost when a card is answered with \'Again\'.')
+            'This form has been deprecated and will be removed the next '
+            'release. <b>On the overview screen</b>, access the new Life Drain '
+            'deck options by using the Life Drain button, or press the '
+            'shortcut L.', '#FF0000', 200, 60)
         self.spin_box('maxLifeInput', 'Maximum life', [1, 10000])
         self.spin_box('recoverInput', 'Recover', [0, 1000])
         self.check_box('enableDamageInput', 'Enable damage')
@@ -319,8 +321,13 @@ class DeckSettings(Form):
         """
         self._form = form
         self._row = 0
-        form.lifedrain_widget = self._qt.QGroupBox('Life Drain')
+        form.lifedrain_widget = self._qt.QGroupBox('Life Drain  ')
         form.lifedrain_layout = self._qt.QGridLayout(form.lifedrain_widget)
+        self.label(
+            'This form has been deprecated and will be removed the next '
+            'release. <b>On the overview screen</b>, access the new Life Drain '
+            'deck options by using the Life Drain button, or press the '
+            'shortcut L.', '#FF0000', 200, 60)
         self.spin_box('maxLifeInput', 'Maximum life', [1, 10000])
         self.spin_box('recoverInput', 'Recover', [0, 1000])
         self.check_box('enableDamageInput', 'Enable damage')

--- a/lifedrain/settings.py
+++ b/lifedrain/settings.py
@@ -289,3 +289,71 @@ class DeckSettings(Form):
             'damage': form.damageInput.value() if enable_damage else None,
             'currentValue': form.currentValueInput.value()
         }
+
+    def old_generate_deck_form(self, form):
+        """Appends a Life Drain tab to Deck Settings dialog.
+        Args:
+            form: The form instance of the Global Settings dialog.
+        """
+        self._form = form
+        self._row = 0
+        form.lifedrain_widget = self._qt.QWidget()
+        form.lifedrain_layout = self._qt.QGridLayout(form.lifedrain_widget)
+        self.label(
+            'The <b>maximum life</b> is the time in seconds for the life bar '
+            'go from full to empty.\n<b>Recover</b> is the time in seconds '
+            'that is recovered after answering a card. <b>Damage</b> is the '
+            'life lost when a card is answered with \'Again\'.')
+        self.spin_box('maxLifeInput', 'Maximum life', [1, 10000])
+        self.spin_box('recoverInput', 'Recover', [0, 1000])
+        self.check_box('enableDamageInput', 'Enable damage')
+        self.spin_box('damageInput', 'Damage', [-1000, 1000])
+        self.spin_box('currentValueInput', 'Current life', [0, 10000])
+        self.fill_space()
+        form.tabWidget.addTab(form.lifedrain_widget, 'Life Drain')
+
+    def old_generate_custom_deck_form(self, form):
+        """Adds Life Drain settings to Filtered Deck Settings dialog.
+        Args:
+            form: The form instance of the Filtered Deck Settings dialog.
+        """
+        self._form = form
+        self._row = 0
+        form.lifedrain_widget = self._qt.QGroupBox('Life Drain')
+        form.lifedrain_layout = self._qt.QGridLayout(form.lifedrain_widget)
+        self.spin_box('maxLifeInput', 'Maximum life', [1, 10000])
+        self.spin_box('recoverInput', 'Recover', [0, 1000])
+        self.check_box('enableDamageInput', 'Enable damage')
+        self.spin_box('damageInput', 'Damage', [-1000, 1000])
+        self.spin_box('currentValueInput', 'Current life', [0, 10000])
+        form.verticalLayout.insertWidget(3, form.lifedrain_widget)
+
+    def old_load_form_data(self, settings, current_life):
+        """Loads Life Drain deck settings into the form.
+        Args:
+            settings: The instance of the Deck Settings dialog.
+            current_life: The current amount of life.
+        """
+        conf = self._deck_conf.get()
+        form = settings.form
+
+        form.maxLifeInput.setValue(conf['maxLife'])
+        form.recoverInput.setValue(conf['recover'])
+        form.enableDamageInput.setChecked(conf['damage'] is not None)
+        form.damageInput.setValue(conf['damage'] or 5)
+        form.currentValueInput.setValue(current_life)
+
+    def old_save_form_data(self, settings, set_deck_conf):
+        """Saves Life Drain deck settings from the form.
+        Args:
+            settings: The instance of the Deck Settings dialog.
+        """
+        conf = self._deck_conf.get()
+        form = settings.form
+        enable_damage = form.enableDamageInput.isChecked()
+        conf['maxLife'] = form.maxLifeInput.value()
+        conf['recover'] = form.recoverInput.value()
+        conf['damage'] = form.damageInput.value() if enable_damage else None
+        conf['currentValue'] = form.currentValueInput.value()
+        set_deck_conf(conf)
+        self._deck_conf.set(conf)


### PR DESCRIPTION
Resolves #59.
Added a deprecation message on the Life Drain settings the users were using so far. 

- The Life Drain tab of the built-in deck options
- The Life Drain form on the built-in filtered deck options.

> This form has been deprecated and will be removed the next release. On the overview screen, access the new Life Drain deck options by using the Life Drain button, or press the shortcut L.

![deckoptions](https://i.imgur.com/A3yb5da.png)