### PR TITLE
Fix some cases where damage value would be wrong

### DIFF
--- a/lifedrain/deck_manager.py
+++ b/lifedrain/deck_manager.py
@@ -57,10 +57,11 @@ class DeckManager:
 
     def get_current_life(self):
         """Get the current deck's current life."""
-        deck_id = self._cur_deck_id
-        if deck_id not in self._bar_info:
-            self._add_deck(deck_id)
-        return self._bar_info[deck_id]['currentValue']
+        conf = self._deck_conf.get()
+        self._cur_deck_id = conf['id']
+        if conf['id'] not in self._bar_info:
+            self._add_deck(conf['id'])
+        return self._bar_info[conf['id']]['currentValue']
 
     def set_deck_conf(self, conf):
         """Updates a deck's current settings and state.

--- a/lifedrain/settings.py
+++ b/lifedrain/settings.py
@@ -279,11 +279,18 @@ current life, in seconds.''')
 
     @staticmethod
     def _load_form_data(form, conf, life):
+        def update_damageinput_state():
+            damage_enabled = form.enableDamageInput.isChecked()
+            form.damageInput.setEnabled(damage_enabled)
+            form.damageInput.setValue(5)
+
         form.maxLifeInput.setValue(conf['maxLife'])
         form.recoverInput.setValue(conf['recover'])
         damage = conf['damage']
         form.enableDamageInput.setChecked(damage is not None)
+        form.enableDamageInput.stateChanged.connect(update_damageinput_state)
         form.damageInput.setValue(damage if damage else 5)
+        form.damageInput.setEnabled(conf['damage'] is not None)
         form.currentValueInput.setValue(life)
 
     @staticmethod
@@ -346,13 +353,20 @@ current life, in seconds.''')
             settings: The instance of the Deck Settings dialog.
             current_life: The current amount of life.
         """
+        def update_damageinput_state():
+            damage_enabled = form.enableDamageInput.isChecked()
+            form.damageInput.setEnabled(damage_enabled)
+            form.damageInput.setValue(5)
+
         conf = self._deck_conf.get()
         form = settings.form
 
         form.maxLifeInput.setValue(conf['maxLife'])
         form.recoverInput.setValue(conf['recover'])
         form.enableDamageInput.setChecked(conf['damage'] is not None)
+        form.enableDamageInput.stateChanged.connect(update_damageinput_state)
         form.damageInput.setValue(conf['damage'] or 5)
+        form.damageInput.setEnabled(conf['damage'] is not None)
         form.currentValueInput.setValue(current_life)
 
     def old_save_form_data(self, settings, set_deck_conf):

--- a/lifedrain/settings.py
+++ b/lifedrain/settings.py
@@ -289,7 +289,7 @@ current life, in seconds.''')
         damage = conf['damage']
         form.enableDamageInput.setChecked(damage is not None)
         form.enableDamageInput.stateChanged.connect(update_damageinput_state)
-        form.damageInput.setValue(damage if damage else 5)
+        form.damageInput.setValue(damage if damage is not None else 5)
         form.damageInput.setEnabled(conf['damage'] is not None)
         form.currentValueInput.setValue(life)
 
@@ -363,9 +363,10 @@ current life, in seconds.''')
 
         form.maxLifeInput.setValue(conf['maxLife'])
         form.recoverInput.setValue(conf['recover'])
-        form.enableDamageInput.setChecked(conf['damage'] is not None)
+        damage = conf['damage']
+        form.enableDamageInput.setChecked(damage is not None)
         form.enableDamageInput.stateChanged.connect(update_damageinput_state)
-        form.damageInput.setValue(conf['damage'] or 5)
+        form.damageInput.setValue(damage if damage is not None else 5)
         form.damageInput.setEnabled(conf['damage'] is not None)
         form.currentValueInput.setValue(current_life)
 


### PR DESCRIPTION
Resolves #77. 
- Damage value was being reset to 5 if set to 0
- Editing the current life from the deck browser wasn't saving the inputted value if you open the deck options again (without going to the overview screen)
- Disable the damage field if damage is not enabled