### PR TITLE
Allow setting bar's background color again

### DIFF
--- a/lifedrain/deck_manager.py
+++ b/lifedrain/deck_manager.py
@@ -132,12 +132,14 @@ class DeckManager:
         self._progress_bar.dock_at(self._get_conf('barPosition'))
         progress_bar_style = {
             'height': self._get_conf('barHeight'),
-            'foregroundColor': self._get_conf('barFgColor'),
+            'fgColor': self._get_conf('barFgColor'),
             'borderRadius': self._get_conf('barBorderRadius'),
             'text': self._get_conf('barText'),
             'textColor': self._get_conf('barTextColor'),
             'customStyle': self._get_conf('barStyle')
         }
+        if self._get_conf('enableBgColor'):
+            progress_bar_style['bgColor'] = self._get_conf('barBgColor')
         self._progress_bar.set_style(progress_bar_style)
 
     def _get_conf(self, key):

--- a/lifedrain/defaults.py
+++ b/lifedrain/defaults.py
@@ -34,10 +34,12 @@ DEFAULTS = {
     'barPosition': POSITION_OPTIONS.index('Bottom'),
     'barHeight': 15,
     'barFgColor': '#489ef6',
+    'barBgColor': '#f3f3f2',
     'barBorderRadius': 0,
     'barText': 0,
     'barTextColor': '#000',
     'barStyle': STYLE_OPTIONS.index('Default'),
     'stopOnAnswer': False,
-    'disable': False
+    'disable': False,
+    'enableBgColor': False
 }

--- a/lifedrain/progress_bar.py
+++ b/lifedrain/progress_bar.py
@@ -97,18 +97,24 @@ class ProgressBar:
         custom_style = STYLE_OPTIONS[options['customStyle']] \
             .replace(' ', '').lower()
         if custom_style != 'default':
-            palette = self._qt.QPalette()
-            palette.setColor(self._qt.QPalette.Highlight,
-                             self._qt.QColor(options['fgColor']))
+            qstyle = self._qt.QStyleFactory.create(custom_style)
+            self._qprogressbar.setStyle(qstyle)
 
-            self._qprogressbar.setStyle(
-                self._qt.QStyleFactory.create(custom_style))
+            palette = self._qt.QPalette()
+            fg_color = self._qt.QColor(options['fgColor'])
+            palette.setColor(self._qt.QPalette.Highlight, fg_color)
+
+            if 'bgColor' in options:
+                bg_color = self._qt.QColor(options['bgColor'])
+                palette.setColor(self._qt.QPalette.Base, bg_color)
+                palette.setColor(self._qt.QPalette.Window, bg_color)
+
             self._qprogressbar.setPalette(palette)
-            self._qprogressbar.setStyleSheet('''
-                QProgressBar {
-                    max-height: %spx;
-                }
-                ''' % (options['height']))
+
+            bar_elem_dict = {'max-height': '{}px'.format(options['height'])}
+            bar_elem = self._dict_to_css(bar_elem_dict)
+            self._qprogressbar.setStyleSheet(
+                'QProgressBar {{ {} }}'.format(bar_elem))
         else:
             bar_elem_dict = {
                 'text-align': 'center',
@@ -127,8 +133,7 @@ class ProgressBar:
 
             self._qprogressbar.setStyleSheet(
                 'QProgressBar {{ {} }}'
-                'QProgressBar::chunk {{ {} }}'.format(bar_elem, bar_chunk)
-            )
+                'QProgressBar::chunk {{ {} }}'.format(bar_elem, bar_chunk))
 
     def dock_at(self, position):
         """Docks the bar at the specified position in the Anki window.

--- a/lifedrain/progress_bar.py
+++ b/lifedrain/progress_bar.py
@@ -99,7 +99,7 @@ class ProgressBar:
         if custom_style != 'default':
             palette = self._qt.QPalette()
             palette.setColor(self._qt.QPalette.Highlight,
-                             self._qt.QColor(options['foregroundColor']))
+                             self._qt.QColor(options['fgColor']))
 
             self._qprogressbar.setStyle(
                 self._qt.QStyleFactory.create(custom_style))
@@ -110,21 +110,25 @@ class ProgressBar:
                 }
                 ''' % (options['height']))
         else:
-            self._qprogressbar.setStyleSheet('''
-                QProgressBar {
-                    text-align:center;
-                    border-radius: %dpx;
-                    max-height: %spx;
-                    color: %s;
-                }
-                QProgressBar::chunk {
-                    background-color: %s;
-                    margin: 0px;
-                    border-radius: %dpx;
-                }
-                ''' % (options['borderRadius'], options['height'],
-                       options['textColor'], options['foregroundColor'],
-                       options['borderRadius']))
+            bar_elem_dict = {
+                'text-align': 'center',
+                'border-radius': '{}px'.format(options['borderRadius']),
+                'max-height': '{}px'.format(options['height']),
+                'color': options['textColor']}
+
+            if 'bgColor' in options:
+                bar_elem_dict['background-color'] = options['bgColor']
+
+            bar_elem = self._dict_to_css(bar_elem_dict)
+            bar_chunk = self._dict_to_css({
+                'background-color': options['fgColor'],
+                'margin': '0px',
+                'border-radius': '{}px'.format(options['borderRadius'])})
+
+            self._qprogressbar.setStyleSheet(
+                'QProgressBar {{ {} }}'
+                'QProgressBar::chunk {{ {} }}'.format(bar_elem, bar_chunk)
+            )
 
     def dock_at(self, position):
         """Docks the bar at the specified position in the Anki window.
@@ -192,3 +196,11 @@ class ProgressBar:
                 '%m', str(max_value)).replace(
                     '%p', str(int(100 * current_value / max_value)))
             self._qprogressbar.setFormat(text)
+
+    @staticmethod
+    def _dict_to_css(dictionary):
+        """Convert a python dict to a stylesheet."""
+        css = ''
+        for key, value in dictionary.items():
+            css += '\n{}: {};'.format(key, value)
+        return css

--- a/lifedrain/settings.py
+++ b/lifedrain/settings.py
@@ -158,6 +158,8 @@ class GlobalSettings(Form):
         self.combo_box('styleList', 'Style', STYLE_OPTIONS)
         self.color_select('fgColor', 'Bar color')
         self.color_select('textColor', 'Text color')
+        self.check_box('enableBgColor', 'Enable custom background color')
+        self.color_select('bgColor', 'Background color')
         self.fill_space()
         form.tabWidget.addTab(form.lifedrain_widget, 'Life Drain')
 
@@ -170,23 +172,29 @@ class GlobalSettings(Form):
         self._conf = pref.mw.col.conf
         form = pref.form
 
+        form.enableAddon.setChecked(not self._get_conf('disable'))
+        form.stopOnAnswer.setChecked(self._get_conf('stopOnAnswer'))
         form.positionList.setCurrentIndex(self._get_conf('barPosition'))
         form.heightInput.setValue(self._get_conf('barHeight'))
+        form.borderRadiusInput.setValue(self._get_conf('barBorderRadius'))
+        form.textList.setCurrentIndex(self._get_conf('barText'))
+        form.styleList.setCurrentIndex(self._get_conf('barStyle'))
         form.fgColorDialog.setCurrentColor(
             self._qt.QColor(self._get_conf('barFgColor')))
         form.fgColorPreview.setStyleSheet(
             'QLabel { background-color: %s; }' %
             form.fgColorDialog.currentColor().name())
-        form.borderRadiusInput.setValue(self._get_conf('barBorderRadius'))
-        form.textList.setCurrentIndex(self._get_conf('barText'))
         form.textColorDialog.setCurrentColor(
             self._qt.QColor(self._get_conf('barTextColor')))
         form.textColorPreview.setStyleSheet(
             'QLabel { background-color: %s; }' %
             form.textColorDialog.currentColor().name())
-        form.styleList.setCurrentIndex(self._get_conf('barStyle'))
-        form.stopOnAnswer.setChecked(self._get_conf('stopOnAnswer'))
-        form.enableAddon.setChecked(not self._get_conf('disable'))
+        form.enableBgColor.setChecked(self._get_conf('enableBgColor'))
+        form.bgColorDialog.setCurrentColor(
+            self._qt.QColor(self._get_conf('barBgColor')))
+        form.bgColorPreview.setStyleSheet(
+            'QLabel { background-color: %s; }' %
+            form.bgColorDialog.currentColor().name())
 
     @staticmethod
     def save_form_data(pref):
@@ -198,17 +206,17 @@ class GlobalSettings(Form):
         conf = pref.mw.col.conf
         form = pref.form
 
+        conf['disable'] = not form.enableAddon.isChecked()
+        conf['stopOnAnswer'] = form.stopOnAnswer.isChecked()
         conf['barPosition'] = form.positionList.currentIndex()
         conf['barHeight'] = form.heightInput.value()
-        conf['barFgColor'] = form.fgColorDialog.currentColor().name()
         conf['barBorderRadius'] = form.borderRadiusInput.value()
         conf['barText'] = form.textList.currentIndex()
-        conf['barTextColor'] = form.textColorDialog.currentColor().name()
         conf['barStyle'] = form.styleList.currentIndex()
-        conf['stopOnAnswer'] = form.stopOnAnswer.isChecked()
-        conf['disable'] = not form.enableAddon.isChecked()
-        if 'barBgColor' in conf:
-            del conf['barBgColor']
+        conf['barFgColor'] = form.fgColorDialog.currentColor().name()
+        conf['barTextColor'] = form.textColorDialog.currentColor().name()
+        conf['enableBgColor'] = form.enableBgColor.isChecked()
+        conf['barBgColor'] = form.bgColorDialog.currentColor().name()
         return conf
 
     def _get_conf(self, key):


### PR DESCRIPTION
Resolves #62.

Feature was removed on 2.1.0, but as it existed since the first version of Life Drain, I decided to add it again.