### PR TITLE
Save Life Drain's global settings into a separated dictionary

### DIFF
--- a/lifedrain/config.py
+++ b/lifedrain/config.py
@@ -6,6 +6,45 @@ See the LICENCE file in the repository root for full licence text.
 from .defaults import DEFAULTS
 
 
+class GlobalConf:
+    """Manages lifedrain's global configuration."""
+    fields = ['stopOnAnswer', 'barPosition', 'barHeight',
+              'barBorderRadius', 'barText', 'barStyle', 'barFgColor',
+              'barTextColor', 'enableBgColor', 'barBgColor']
+    _main_window = None
+
+    def __init__(self, mw):
+        self._main_window = mw
+
+    def get(self):
+        """Get global configuration from Anki's database."""
+        col = self._main_window.col
+        conf = col.conf
+
+        global_conf = conf.get('lifedrain')
+        if global_conf is None:
+            conf_dict = {}
+            for field in self.fields:
+                conf_dict[field] = conf.get(field, DEFAULTS[field])
+            enable = not conf.get('disable', not DEFAULTS['enable'])
+            conf_dict['enable'] = enable
+            return conf_dict
+
+        return global_conf.copy()
+
+    def set(self, new_conf):
+        """Saves global configuration into Anki's database."""
+        col = self._main_window.col
+        conf = col.conf
+
+        if 'lifedrain' not in conf:
+            conf['lifedrain'] = {}
+        for field in self.fields:
+            conf['lifedrain'][field] = new_conf[field]
+        conf['lifedrain']['enable'] = new_conf['enable']
+        col.setMod()
+
+
 class DeckConf:
     """Manages each lifedrain's deck configuration."""
     fields = ['maxLife', 'recover', 'damage']
@@ -28,7 +67,7 @@ class DeckConf:
         return conf_dict
 
     def set(self, new_conf):
-        """Set and saves deck configuration into Anki's database."""
+        """Saves deck configuration into Anki's database."""
         col = self._main_window.col
         deck = col.decks.current()
 

--- a/lifedrain/deck_manager.py
+++ b/lifedrain/deck_manager.py
@@ -5,7 +5,6 @@ See the LICENCE file in the repository root for full licence text.
 
 from anki.hooks import runHook
 
-from .defaults import DEFAULTS
 from .progress_bar import ProgressBar
 
 
@@ -23,13 +22,13 @@ class DeckManager:
 
     _bar_info = {}
     _conf = None
+    _global_conf = None
     _deck_conf = None
     _game_over = False
-    _main_window = None
     _progress_bar = None
     _cur_deck_id = None
 
-    def __init__(self, mw, qt, deck_conf):
+    def __init__(self, mw, qt, global_conf, deck_conf):
         """Initializes a Progress Bar, and keeps Anki's main window reference.
 
         Args:
@@ -37,7 +36,7 @@ class DeckManager:
             qt: The PyQt library.
         """
         self._progress_bar = ProgressBar(mw, qt)
-        self._main_window = mw
+        self._global_conf = global_conf
         self._deck_conf = deck_conf
         self.bar_visible = self._progress_bar.set_visible
 
@@ -128,20 +127,15 @@ class DeckManager:
 
     def _update_progress_bar_style(self):
         """Synchronizes the Progress Bar styling with the Global Settings."""
-        self._conf = self._main_window.col.conf
-        self._progress_bar.dock_at(self._get_conf('barPosition'))
+        conf = self._global_conf.get()
+        self._progress_bar.dock_at(conf['barPosition'])
         progress_bar_style = {
-            'height': self._get_conf('barHeight'),
-            'fgColor': self._get_conf('barFgColor'),
-            'borderRadius': self._get_conf('barBorderRadius'),
-            'text': self._get_conf('barText'),
-            'textColor': self._get_conf('barTextColor'),
-            'customStyle': self._get_conf('barStyle')
-        }
-        if self._get_conf('enableBgColor'):
-            progress_bar_style['bgColor'] = self._get_conf('barBgColor')
+            'height': conf['barHeight'],
+            'fgColor': conf['barFgColor'],
+            'borderRadius': conf['barBorderRadius'],
+            'text': conf['barText'],
+            'textColor': conf['barTextColor'],
+            'customStyle': conf['barStyle']}
+        if conf['enableBgColor']:
+            progress_bar_style['bgColor'] = conf['barBgColor']
         self._progress_bar.set_style(progress_bar_style)
-
-    def _get_conf(self, key):
-        """Gets the value of a configuration."""
-        return self._conf.get(key, DEFAULTS[key])

--- a/lifedrain/decorators.py
+++ b/lifedrain/decorators.py
@@ -10,8 +10,16 @@ def must_be_enabled(func):
     """Runs the method only if the add-on is enabled."""
     def _wrapper(self, *args, **kwargs):
         col = self.main_window.col
-        if col is None or col.conf.get('disable', DEFAULTS['disable']) is True:
+        if col is None:
             return None
+
+        global_conf = col.conf.get('lifedrain')
+        if global_conf is None:
+            if col.conf.get('disable', not DEFAULTS['enable']):
+                return None
+        elif not global_conf['enable']:
+            return None
+
         return func(self, *args, **kwargs)
 
     return _wrapper

--- a/lifedrain/defaults.py
+++ b/lifedrain/defaults.py
@@ -40,6 +40,6 @@ DEFAULTS = {
     'barTextColor': '#000',
     'barStyle': STYLE_OPTIONS.index('Default'),
     'stopOnAnswer': False,
-    'disable': False,
+    'enable': True,
     'enableBgColor': False
 }

--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -3,7 +3,7 @@ Copyright (c) Yutsuten <https://github.com/Yutsuten>. Licensed under AGPL-3.0.
 See the LICENCE file in the repository root for full licence text.
 """
 
-from .config import DeckConf
+from .config import GlobalConf, DeckConf
 from .deck_manager import DeckManager
 from .decorators import must_be_enabled
 from .defaults import DEFAULTS
@@ -47,11 +47,12 @@ class Lifedrain:
             mw: Anki's main window.
             qt: The PyQt library.
         """
+        global_conf = GlobalConf(mw)
         deck_conf = DeckConf(mw)
 
-        self.deck_manager = DeckManager(mw, qt, deck_conf)
+        self.deck_manager = DeckManager(mw, qt, global_conf, deck_conf)
         self.main_window = mw
-        self._global_settings = GlobalSettings(qt)
+        self._global_settings = GlobalSettings(qt, global_conf)
         self._deck_settings = DeckSettings(qt, deck_conf)
         self._timer = make_timer(
             100, lambda: self.deck_manager.recover_life(False, 0.1), True)
@@ -79,7 +80,7 @@ class Lifedrain:
         self.status['card_new_state'] = True
         self.status['reviewed'] = False
 
-        if conf['disable'] is True:
+        if conf['enable'] is False:
             self.deck_manager.bar_visible(False)
 
     def deck_settings(self):

--- a/lifedrain/settings.py
+++ b/lifedrain/settings.py
@@ -5,7 +5,7 @@ See the LICENCE file in the repository root for full licence text.
 
 from operator import itemgetter
 
-from .defaults import DEFAULTS, POSITION_OPTIONS, STYLE_OPTIONS, TEXT_FORMAT
+from .defaults import POSITION_OPTIONS, STYLE_OPTIONS, TEXT_FORMAT
 
 
 class Form:
@@ -134,8 +134,11 @@ class Form:
 
 class GlobalSettings(Form):
     """Creates the User Interfaces for configurating the add-on."""
-    def __init__(self, qt):
+    _global_conf = None
+
+    def __init__(self, qt, global_conf):
         Form.__init__(self, qt)
+        self._global_conf = global_conf
 
     def generate_form(self, form):
         """Appends a Life Drain tab to the Global Settings dialog.
@@ -169,59 +172,52 @@ class GlobalSettings(Form):
         Args:
             pref: The instance of the Global Settings dialog.
         """
-        self._conf = pref.mw.col.conf
+        conf = self._global_conf.get()
         form = pref.form
 
-        form.enableAddon.setChecked(not self._get_conf('disable'))
-        form.stopOnAnswer.setChecked(self._get_conf('stopOnAnswer'))
-        form.positionList.setCurrentIndex(self._get_conf('barPosition'))
-        form.heightInput.setValue(self._get_conf('barHeight'))
-        form.borderRadiusInput.setValue(self._get_conf('barBorderRadius'))
-        form.textList.setCurrentIndex(self._get_conf('barText'))
-        form.styleList.setCurrentIndex(self._get_conf('barStyle'))
-        form.fgColorDialog.setCurrentColor(
-            self._qt.QColor(self._get_conf('barFgColor')))
+        form.enableAddon.setChecked(conf['enable'])
+        form.stopOnAnswer.setChecked(conf['stopOnAnswer'])
+        form.positionList.setCurrentIndex(conf['barPosition'])
+        form.heightInput.setValue(conf['barHeight'])
+        form.borderRadiusInput.setValue(conf['barBorderRadius'])
+        form.textList.setCurrentIndex(conf['barText'])
+        form.styleList.setCurrentIndex(conf['barStyle'])
+        form.fgColorDialog.setCurrentColor(self._qt.QColor(conf['barFgColor']))
         form.fgColorPreview.setStyleSheet(
             'QLabel { background-color: %s; }' %
             form.fgColorDialog.currentColor().name())
         form.textColorDialog.setCurrentColor(
-            self._qt.QColor(self._get_conf('barTextColor')))
+            self._qt.QColor(conf['barTextColor']))
         form.textColorPreview.setStyleSheet(
             'QLabel { background-color: %s; }' %
             form.textColorDialog.currentColor().name())
-        form.enableBgColor.setChecked(self._get_conf('enableBgColor'))
-        form.bgColorDialog.setCurrentColor(
-            self._qt.QColor(self._get_conf('barBgColor')))
+        form.enableBgColor.setChecked(conf['enableBgColor'])
+        form.bgColorDialog.setCurrentColor(self._qt.QColor(conf['barBgColor']))
         form.bgColorPreview.setStyleSheet(
             'QLabel { background-color: %s; }' %
             form.bgColorDialog.currentColor().name())
 
-    @staticmethod
-    def save_form_data(pref):
+    def save_form_data(self, pref):
         """Saves Life Drain global settings from the form.
 
         Args:
             pref: The instance of the Global Settings dialog.
         """
-        conf = pref.mw.col.conf
         form = pref.form
-
-        conf['disable'] = not form.enableAddon.isChecked()
-        conf['stopOnAnswer'] = form.stopOnAnswer.isChecked()
-        conf['barPosition'] = form.positionList.currentIndex()
-        conf['barHeight'] = form.heightInput.value()
-        conf['barBorderRadius'] = form.borderRadiusInput.value()
-        conf['barText'] = form.textList.currentIndex()
-        conf['barStyle'] = form.styleList.currentIndex()
-        conf['barFgColor'] = form.fgColorDialog.currentColor().name()
-        conf['barTextColor'] = form.textColorDialog.currentColor().name()
-        conf['enableBgColor'] = form.enableBgColor.isChecked()
-        conf['barBgColor'] = form.bgColorDialog.currentColor().name()
+        conf = {
+            'enable': form.enableAddon.isChecked(),
+            'stopOnAnswer': form.stopOnAnswer.isChecked(),
+            'barPosition': form.positionList.currentIndex(),
+            'barHeight': form.heightInput.value(),
+            'barBorderRadius': form.borderRadiusInput.value(),
+            'barText': form.textList.currentIndex(),
+            'barStyle': form.styleList.currentIndex(),
+            'barFgColor': form.fgColorDialog.currentColor().name(),
+            'barTextColor': form.textColorDialog.currentColor().name(),
+            'enableBgColor': form.enableBgColor.isChecked(),
+            'barBgColor': form.bgColorDialog.currentColor().name()}
+        self._global_conf.set(conf)
         return conf
-
-    def _get_conf(self, key):
-        """Gets the value of a configuration."""
-        return self._conf.get(key, DEFAULTS[key])
 
 
 class DeckSettings(Form):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,133 @@ from unittest import mock
 from tests.test_base import LifedrainTestCase
 
 
+class TestGlobalConf(LifedrainTestCase):
+
+    def test_get_default(self):
+        main_window = mock.MagicMock()
+        main_window.col.conf = {}
+
+        global_conf = self.lifedrain.config.GlobalConf(main_window)
+        conf = global_conf.get()
+
+        DEFAULTS = self.lifedrain.defaults.DEFAULTS
+        expected_conf = {
+            'enable': DEFAULTS['enable'],
+            'stopOnAnswer': DEFAULTS['stopOnAnswer'],
+            'barPosition': DEFAULTS['barPosition'],
+            'barHeight': DEFAULTS['barHeight'],
+            'barBorderRadius': DEFAULTS['barBorderRadius'],
+            'barText': DEFAULTS['barText'],
+            'barStyle': DEFAULTS['barStyle'],
+            'barFgColor': DEFAULTS['barFgColor'],
+            'barTextColor': DEFAULTS['barTextColor'],
+            'enableBgColor': DEFAULTS['enableBgColor'],
+            'barBgColor': DEFAULTS['barBgColor']}
+        self.assertEqual(conf, expected_conf)
+
+    def test_get_previous_settings(self):
+        main_window = mock.MagicMock()
+        main_window.col.conf = {
+            'disable': True,
+            'stopOnAnswer': True,
+            'barPosition': 1,
+            'barHeight': 20,
+            'barBorderRadius': 3,
+            'barText': 2,
+            'barStyle': 6,
+            'barFgColor': '#abcdef',
+            'barTextColor': '#123456',
+            'enableBgColor': True,
+            'barBgColor': '#foobar'}
+
+        global_conf = self.lifedrain.config.GlobalConf(main_window)
+        conf = global_conf.get()
+
+        expected_conf = main_window.col.conf.copy()
+        expected_conf['enable'] = not expected_conf.pop('disable')
+        self.assertEqual(conf, expected_conf)
+
+    def test_get_custom(self):
+        main_window = mock.MagicMock()
+        main_window.col.conf = {
+            'lifedrain': {
+                'enable': False,
+                'stopOnAnswer': True,
+                'barPosition': 1,
+                'barHeight': 20,
+                'barBorderRadius': 3,
+                'barText': 2,
+                'barStyle': 6,
+                'barFgColor': '#abcdef',
+                'barTextColor': '#123456',
+                'enableBgColor': True,
+                'barBgColor': '#foobar'}}
+
+        global_conf = self.lifedrain.config.GlobalConf(main_window)
+        conf = global_conf.get()
+
+        expected_conf = main_window.col.conf['lifedrain']
+        self.assertEqual(conf, expected_conf)
+
+    def test_set_first_time(self):
+        main_window = mock.MagicMock()
+        main_window.col.conf = {}
+
+        global_conf = self.lifedrain.config.GlobalConf(main_window)
+        conf = {
+            'enable': False,
+            'stopOnAnswer': True,
+            'barPosition': 1,
+            'barHeight': 20,
+            'barBorderRadius': 3,
+            'barText': 2,
+            'barStyle': 6,
+            'barFgColor': '#abcdef',
+            'barTextColor': '#123456',
+            'enableBgColor': True,
+            'barBgColor': '#foobar'}
+        global_conf.set(conf)
+
+        expected_conf = {'lifedrain': conf}
+        self.assertEqual(main_window.col.conf, expected_conf)
+        main_window.col.setMod.assert_called_once_with()
+
+    def test_set_overwrite(self):
+        main_window = mock.MagicMock()
+        main_window.col.conf = {
+            'lifedrain': {
+                'enable': True,
+                'stopOnAnswer': False,
+                'barPosition': 1,
+                'barHeight': 15,
+                'barBorderRadius': 0,
+                'barText': 0,
+                'barStyle': 0,
+                'barFgColor': '#aaaaaa',
+                'barTextColor': '#a1b2c3',
+                'enableBgColor': False,
+                'barBgColor': '#555444'}}
+
+        global_conf = self.lifedrain.config.GlobalConf(main_window)
+        conf = {
+            'enable': False,
+            'stopOnAnswer': True,
+            'barPosition': 1,
+            'barHeight': 20,
+            'barBorderRadius': 3,
+            'barText': 2,
+            'barStyle': 6,
+            'barFgColor': '#abcdef',
+            'barTextColor': '#123456',
+            'enableBgColor': True,
+            'barBgColor': '#foobar'}
+        global_conf.set(conf)
+
+        expected_conf = {'lifedrain': conf}
+        self.assertEqual(main_window.col.conf, expected_conf)
+        main_window.col.setMod.assert_called_once_with()
+
+
 class TestDeckConf(LifedrainTestCase):
 
     def test_get_default(self):


### PR DESCRIPTION
Resolves #71.

Created a `GlobalConf` to manage global configuration in a similar way `DeckConf` does. The creation of this class will ease the completion of #82. 

I'm also changing the name of `disable` variable in the database to `enable`, which makes more sense for me.