### PR TITLE
Automatically pause when editing / browsing cards

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,4 @@
 [MASTER]
-init-hook='import os, sys; sys.path.append("{}/anki/qt".format(os.getcwd()))'
 ignore-patterns=test_*
 
 [MESSAGES CONTROL]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 run:
-	anki -p Test
+	env QTWEBENGINE_CHROMIUM_FLAGS=--no-sandbox anki -p Test
 
 build: prepare
 	(cd src && zip -r ../dist/lifedrain21.zip * -x "*.pyc")

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ class GlobalConf:
               'barTextColor', 'enableBgColor', 'barBgColor',
               'globalSettingsShortcut', 'deckSettingsShortcut',
               'pauseShortcut', 'recoverShortcut', 'behavUndo', 'behavBury',
-              'behavSuspend'}
+              'behavSuspend', 'stopOnLostFocus'}
     _main_window = None
 
     def __init__(self, mw):

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -43,6 +43,7 @@ DEFAULTS = {
     'barTextColor': '#000',
     'barStyle': STYLE_OPTIONS.index('Default'),
     'stopOnAnswer': False,
+    'stopOnLostFocus': True,
     'enable': True,
     'enableBgColor': False,
     'globalSettingsShortcut': 'Ctrl+l',

--- a/src/lifedrain.py
+++ b/src/lifedrain.py
@@ -168,6 +168,11 @@ class Lifedrain:
             self.deck_manager.bar_visible(True)
 
     @must_be_enabled
+    def opened_window(self, config):
+        """Called when a window is opened while reviewing."""
+        self.toggle_drain(False)
+
+    @must_be_enabled
     def show_question(self, config, card):
         """Called when a question is shown."""
         self.toggle_drain(True)

--- a/src/lifedrain.py
+++ b/src/lifedrain.py
@@ -170,7 +170,8 @@ class Lifedrain:
     @must_be_enabled
     def opened_window(self, config):
         """Called when a window is opened while reviewing."""
-        self.toggle_drain(False)
+        if config['stopOnLostFocus']:
+            self.toggle_drain(False)
 
     @must_be_enabled
     def show_question(self, config, card):

--- a/src/main.py
+++ b/src/main.py
@@ -118,13 +118,13 @@ def setup_review(lifedrain):
     gui_hooks.review_did_undo.append(lambda card_id: lifedrain.undo())
 
     gui_hooks.browser_will_show.append(
-        lambda browser: lifedrain.toggle_drain(False))
+        lambda browser: lifedrain.opened_window())
     gui_hooks.editor_did_init.append(
-        lambda editor: lifedrain.toggle_drain(False))
+        lambda editor: lifedrain.opened_window())
     gui_hooks.deck_options_did_load.append(
-        lambda deck_options: lifedrain.toggle_drain(False))
+        lambda deck_options: lifedrain.opened_window())
     gui_hooks.filtered_deck_dialog_did_load_deck.append(
-        lambda *args: lifedrain.toggle_drain(False))
+        lambda *args: lifedrain.opened_window())
 
     # Action on cards
     hooks.card_did_leech.append(

--- a/src/main.py
+++ b/src/main.py
@@ -117,6 +117,15 @@ def setup_review(lifedrain):
         lambda *args: lifedrain.status.update({'review_response': args[2]}))
     gui_hooks.review_did_undo.append(lambda card_id: lifedrain.undo())
 
+    gui_hooks.browser_will_show.append(
+        lambda browser: lifedrain.toggle_drain(False))
+    gui_hooks.editor_did_init.append(
+        lambda editor: lifedrain.toggle_drain(False))
+    gui_hooks.deck_options_did_load.append(
+        lambda deck_options: lifedrain.toggle_drain(False))
+    gui_hooks.filtered_deck_dialog_did_load_deck.append(
+        lambda *args: lifedrain.toggle_drain(False))
+
     # Action on cards
     hooks.card_did_leech.append(
         lambda *args: lifedrain.status.update({'special_action': True}))

--- a/src/settings.py
+++ b/src/settings.py
@@ -192,6 +192,7 @@ def global_settings(aqt, config):
         config.set({
             'enable': basic_tab.enableAddon.get_value(),
             'stopOnAnswer': basic_tab.stopOnAnswer.get_value(),
+            'stopOnLostFocus': basic_tab.stopOnLostFocus.get_value(),
             'globalSettingsShortcut': basic_tab.globalShortcut.get_value(),
             'deckSettingsShortcut': basic_tab.deckShortcut.get_value(),
             'pauseShortcut': basic_tab.pauseShortcut.get_value(),
@@ -243,6 +244,11 @@ def _global_basic_tab(aqt, conf):
                       'Enable/disable the add-on without restarting Anki.')
         tab.check_box('stopOnAnswer', 'Stop drain on answer shown',
                       'Automatically stops the drain after answering a card.')
+        tab.check_box('stopOnLostFocus',
+                      'Stop drain while edititing or browsing',
+                      '''Automatically stops the drain when opening the \
+editor or browser.
+May not resume the drain automatically when closing it.''')
         tab.label('<b>Special action behavior</b>')
         tab.combo_box('behavUndo', 'Undo', BEHAVIORS, '''How should the \
 program behave when undoing?''')
@@ -268,6 +274,7 @@ Invalid shortcuts, or already used shortcuts won't work.'''
     def load_data(widget, conf):
         widget.enableAddon.set_value(conf['enable'])
         widget.stopOnAnswer.set_value(conf['stopOnAnswer'])
+        widget.stopOnLostFocus.set_value(conf['stopOnLostFocus'])
         widget.behavUndo.set_value(conf['behavUndo'])
         widget.behavBury.set_value(conf['behavBury'])
         widget.behavSuspend.set_value(conf['behavSuspend'])


### PR DESCRIPTION
Resolves #115 

I plan to add an option allowing to choose whether to pause or not on those situations.
From my point of view pausing is the expected behaviour, so it will be enabled (will pause automatically) by default.

Seems that there is no built-in hook for when those windows close, so the drain won't resume automatically. Not sure what I'll do about this (would like to avoid monkey patching...).