### PR TITLE
Fix TypeError on newer versions of Anki

### DIFF
--- a/src/progress_bar.py
+++ b/src/progress_bar.py
@@ -63,7 +63,7 @@ class ProgressBar:
         Args:
             current_value: The current value of the bar. Up to 1 decimal place.
         """
-        self._current_value = current_value * 10
+        self._current_value = int(current_value * 10)
         self._validate_current_value()
         self._update_text()
 
@@ -73,7 +73,7 @@ class ProgressBar:
         Args:
             increment: A positive or negative number. Up to 1 decimal place.
         """
-        self._current_value += increment * 10
+        self._current_value += int(increment * 10)
         self._validate_current_value()
         if self._current_value % 10 == 0 or abs(increment) >= 1:
             self._update_text()


### PR DESCRIPTION
Resolves #121

```
File "/home/grim/.local/share/Anki2/addons21/715575551/progress_bar.py", line 183, in _validate_current_value
self._qprogressbar.setValue(self._current_value)
TypeError: setValue(self, int): argument 1 has unexpected type 'float'
```