### PR TITLE
Undo and other actions revamp

### DIFF
--- a/src/deck_manager.py
+++ b/src/deck_manager.py
@@ -53,6 +53,8 @@ class DeckManager:
         bar_info = self._bar_info[deck_id]
         self._progress_bar.set_max_value(bar_info['maxValue'])
         self._progress_bar.set_current_value(bar_info['currentValue'])
+        history = bar_info['history']
+        history[bar_info['currentReview']] = bar_info['currentValue']
 
     def get_current_life(self):
         """Get the current deck's current life."""

--- a/src/lifedrain.py
+++ b/src/lifedrain.py
@@ -189,7 +189,7 @@ class Lifedrain:
         elif self.status['action'] == 'suspend':
             self.deck_manager.action(config['behavSuspend'])
         elif self.status['action'] == 'delete':
-            pass
+            self.deck_manager.action(config['behavUndo'])
         elif self.status['reviewed']:
             self.deck_manager.answer(
                 self.status['review_response'],

--- a/src/lifedrain.py
+++ b/src/lifedrain.py
@@ -24,7 +24,7 @@ class Lifedrain:
     config = None
     deck_manager = None
     status = {
-        'special_action': False,  # Flag for bury, suspend, remove, leech
+        'action': None,  # Flag for bury, suspend, delete
         'reviewed': False,
         'review_response': 0,
         'screen': None,
@@ -160,7 +160,10 @@ class Lifedrain:
             self.status['prev_card'] = None
 
         if self.status['reviewed'] and state in ['overview', 'review']:
-            self.deck_manager.recover_life()
+            self.deck_manager.answer(
+                self.status['review_response'],
+                self.status['card_type'],
+            )
             self.status['reviewed'] = False
 
         if state == 'deckBrowser':
@@ -179,14 +182,21 @@ class Lifedrain:
     def show_question(self, config, card):
         """Called when a question is shown."""
         self.toggle_drain(True)
-        if self.status['reviewed']:
-            recover_life = self.deck_manager.recover_life
-            if self.status['review_response'] == 1:
-                recover_life(damage=True, card_type=self.status['card_type'])
-            else:
-                recover_life()
+        if self.status['action'] == 'undo':
+            self.deck_manager.undo()
+        elif self.status['action'] == 'bury':
+            self.deck_manager.action(config['behavBury'])
+        elif self.status['action'] == 'suspend':
+            self.deck_manager.action(config['behavSuspend'])
+        elif self.status['action'] == 'delete':
+            pass
+        elif self.status['reviewed']:
+            self.deck_manager.answer(
+                self.status['review_response'],
+                self.status['card_type'],
+            )
         self.status['reviewed'] = False
-        self.status['special_action'] = False
+        self.status['action'] = None
         self.status['card_type'] = card.type
 
     @must_be_enabled
@@ -194,30 +204,3 @@ class Lifedrain:
         """Called when an answer is shown."""
         self.toggle_drain(not config['stopOnAnswer'])
         self.status['reviewed'] = True
-
-    @must_be_enabled
-    def undo(self, config):
-        """Called when an undo event happens on Anki. Not so accurate though."""
-        on_review = self.status['screen'] == 'review'
-        if on_review and not self.status['special_action']:
-            self.status['reviewed'] = False
-            self._special_action_behavior(config['behavUndo'])
-        self.status['special_action'] = False
-
-    @must_be_enabled
-    def bury(self, config):
-        """Called when a card or note is buried."""
-        self.status['special_action'] = True
-        self._special_action_behavior(config['behavBury'])
-
-    @must_be_enabled
-    def suspend(self, config):
-        """Called when a card or note is suspended."""
-        self.status['special_action'] = True
-        self._special_action_behavior(config['behavSuspend'])
-
-    def _special_action_behavior(self, behavior_index):
-        if behavior_index == 0:
-            self.deck_manager.recover_life(False)
-        elif behavior_index == 2:
-            self.deck_manager.recover_life(True)

--- a/src/main.py
+++ b/src/main.py
@@ -114,8 +114,10 @@ def setup_review(lifedrain):
         lambda card: lifedrain.show_answer())
     gui_hooks.reviewer_did_answer_card.append(
         lambda *args: lifedrain.status.update({'review_response': args[2]}))
-    gui_hooks.review_did_undo.append(lambda card_id: lifedrain.undo())
-    gui_hooks.state_did_undo.append(lambda out: lifedrain.undo())
+    gui_hooks.review_did_undo.append(
+        lambda card_id: lifedrain.status.update({'action': 'undo'}))
+    gui_hooks.state_did_undo.append(
+        lambda out: lifedrain.status.update({'action': 'undo'}))
 
     gui_hooks.browser_will_show.append(
         lambda browser: lifedrain.opened_window())
@@ -127,24 +129,22 @@ def setup_review(lifedrain):
         lambda *args: lifedrain.opened_window())
 
     # Action on cards
-    hooks.card_did_leech.append(
-        lambda *args: lifedrain.status.update({'special_action': True}))
     hooks.notes_will_be_deleted.append(
-        lambda *args: lifedrain.status.update({'special_action': True}))
+        lambda *args: lifedrain.status.update({'action': 'delete'}))
 
     Reviewer.suspend_current_note = hooks.wrap(
         Reviewer.suspend_current_note,
-        lambda *args: lifedrain.suspend(),
+        lambda *args: lifedrain.status.update({'action': 'suspend'}),
     )
     Reviewer.suspend_current_card = hooks.wrap(
         Reviewer.suspend_current_card,
-        lambda *args: lifedrain.suspend(),
+        lambda *args: lifedrain.status.update({'action': 'suspend'}),
     )
     Reviewer.bury_current_note = hooks.wrap(
         Reviewer.bury_current_note,
-        lambda *args: lifedrain.bury(),
+        lambda *args: lifedrain.status.update({'action': 'bury'}),
     )
     Reviewer.bury_current_card = hooks.wrap(
         Reviewer.bury_current_card,
-        lambda *args: lifedrain.bury(),
+        lambda *args: lifedrain.status.update({'action': 'bury'}),
     )

--- a/src/main.py
+++ b/src/main.py
@@ -6,10 +6,10 @@ See the LICENCE file in the repository root for full licence text.
 from aqt import mw, qt, gui_hooks
 from aqt.overview import OverviewBottomBar
 from aqt.progress import ProgressManager
+from aqt.reviewer import Reviewer
 from aqt.toolbar import BottomBar
 
 from anki import hooks
-from anki.sched import Scheduler
 
 from .lifedrain import Lifedrain
 
@@ -115,6 +115,7 @@ def setup_review(lifedrain):
     gui_hooks.reviewer_did_answer_card.append(
         lambda *args: lifedrain.status.update({'review_response': args[2]}))
     gui_hooks.review_did_undo.append(lambda card_id: lifedrain.undo())
+    gui_hooks.state_did_undo.append(lambda out: lifedrain.undo())
 
     gui_hooks.browser_will_show.append(
         lambda browser: lifedrain.opened_window())
@@ -130,9 +131,20 @@ def setup_review(lifedrain):
         lambda *args: lifedrain.status.update({'special_action': True}))
     hooks.notes_will_be_deleted.append(
         lambda *args: lifedrain.status.update({'special_action': True}))
-    Scheduler.buryCards = hooks.wrap(
-        Scheduler.buryCards,
-        lambda *args: lifedrain.bury())
-    Scheduler.suspendCards = hooks.wrap(
-        Scheduler.suspendCards,
-        lambda *args: lifedrain.suspend())
+
+    Reviewer.suspend_current_note = hooks.wrap(
+        Reviewer.suspend_current_note,
+        lambda *args: lifedrain.suspend(),
+    )
+    Reviewer.suspend_current_card = hooks.wrap(
+        Reviewer.suspend_current_card,
+        lambda *args: lifedrain.suspend(),
+    )
+    Reviewer.bury_current_note = hooks.wrap(
+        Reviewer.bury_current_note,
+        lambda *args: lifedrain.bury(),
+    )
+    Reviewer.bury_current_card = hooks.wrap(
+        Reviewer.bury_current_card,
+        lambda *args: lifedrain.bury(),
+    )

--- a/src/settings.py
+++ b/src/settings.py
@@ -281,8 +281,8 @@ def _global_basic_tab(aqt, conf):
 editor or browser.
 May not resume the drain automatically when closing it.''')
         tab.label('<b>Special action behavior</b>')
-        tab.combo_box('behavUndo', 'Undo', BEHAVIORS, '''How should the \
-program behave when undoing?''')
+        tab.combo_box('behavUndo', 'Delete', BEHAVIORS, '''How should the \
+program behave when deleting a card/note?''')
         tab.combo_box('behavBury', 'Bury', BEHAVIORS, '''How should the \
 program behave when burying a card/note?''')
         tab.combo_box('behavSuspend', 'Suspend', BEHAVIORS, '''How should the \


### PR DESCRIPTION
Resolves #114 

**Undo revamp**
- Undo has had a very simplist handling so far, only draining, or recovering.
- But now the add-on does save a life history, so now it should return to the life you had before answering the card you returned.

**Delete card/note behavior**
- Now it is also possible to customize the delete behavior (drain or recover).

**Hooks update**
- Now it should support newer versions of the scheduler (v3).
