### PR TITLE
Allow configuring the default initial life to 0

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -8,13 +8,14 @@ from .defaults import DEFAULTS
 
 class GlobalConf:
     """Manages lifedrain's global configuration."""
-    fields = {'enable', 'stopOnAnswer', 'barPosition', 'barHeight',
-              'barBorderRadius', 'barText', 'barStyle', 'barFgColor',
-              'barTextColor', 'enableBgColor', 'barBgColor',
-              'globalSettingsShortcut', 'deckSettingsShortcut',
-              'pauseShortcut', 'recoverShortcut', 'behavUndo', 'behavBury',
-              'behavSuspend', 'stopOnLostFocus', 'shareDrain', 'barThresholdWarn',
-              'barFgColorWarn', 'barThresholdDanger', 'barFgColorDanger'}
+    fields = {
+        'enable', 'stopOnAnswer', 'barPosition', 'barHeight', 'barBorderRadius', 'barText',
+        'barStyle', 'barFgColor', 'barTextColor', 'enableBgColor', 'barBgColor',
+        'globalSettingsShortcut', 'deckSettingsShortcut', 'pauseShortcut', 'recoverShortcut',
+        'behavUndo', 'behavBury', 'behavSuspend', 'stopOnLostFocus', 'shareDrain',
+        'barThresholdWarn', 'barFgColorWarn', 'barThresholdDanger', 'barFgColorDanger',
+        'startEmpty',
+    }
 
     def __init__(self, mw: AnkiQt):
         self._mw = mw

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -46,6 +46,7 @@ DEFAULTS = {
     'barStyle': STYLE_OPTIONS.index('Default'),
     'stopOnAnswer': False,
     'stopOnLostFocus': True,
+    'startEmpty': False,
     'enable': True,
     'enableBgColor': False,
     'globalSettingsShortcut': 'Ctrl+Shift+L',

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -53,7 +53,7 @@ DEFAULTS = {
     'deckSettingsShortcut': 'Ctrl+L',
     'pauseShortcut': 'P',
     'recoverShortcut': '',
-    'behavUndo': BEHAVIORS.index('Drain life'),
+    'behavUndo': BEHAVIORS.index('Do nothing'),
     'behavBury': BEHAVIORS.index('Do nothing'),
     'behavSuspend': BEHAVIORS.index('Do nothing'),
     'shareDrain': False,

--- a/src/lifedrain.py
+++ b/src/lifedrain.py
@@ -125,7 +125,7 @@ class Lifedrain:
             )
         if config['recoverShortcut']:
             def full_recover() -> None:
-                self.deck_manager.recover(10000)
+                self.deck_manager.recover()
 
             shortcuts.append(
                 (config['recoverShortcut'], full_recover),

--- a/src/main.py
+++ b/src/main.py
@@ -86,7 +86,7 @@ def setup_overview(lifedrain: Lifedrain) -> None:
             if url == 'lifedrain':
                 lifedrain.deck_settings()
             elif url == 'recover':
-                lifedrain.deck_manager.recover(10000)
+                lifedrain.deck_manager.recover()
             return link_handler(url=url)
 
         return custom_link_handler

--- a/src/settings.py
+++ b/src/settings.py
@@ -485,7 +485,7 @@ def deck_settings(aqt: Any, mw: AnkiQt, config: DeckConf, global_config: GlobalC
 
     conf = config.get()
     dialog = aqt.QDialog(mw)
-    dialog.setWindowTitle(f'Life Drain options for {conf["name"]}')
+    dialog.setWindowTitle(f'Life Drain Deck Settings for {conf["name"]}')
 
     global_conf = global_config.get()
     if global_conf['shareDrain']:

--- a/src/settings.py
+++ b/src/settings.py
@@ -217,6 +217,7 @@ def global_settings(aqt: Any, mw: AnkiQt, config: GlobalConf, deck_manager: Deck
             'enable': basic_tab.enableAddon.get_value(),
             'stopOnAnswer': basic_tab.stopOnAnswer.get_value(),
             'stopOnLostFocus': basic_tab.stopOnLostFocus.get_value(),
+            'startEmpty': basic_tab.startEmpty.get_value(),
             'globalSettingsShortcut': basic_tab.globalShortcut.get_value(),
             'deckSettingsShortcut': basic_tab.deckShortcut.get_value(),
             'pauseShortcut': basic_tab.pauseShortcut.get_value(),
@@ -291,6 +292,8 @@ def _global_basic_tab(aqt: Any, conf: dict) -> Any:
                       '''Automatically stops the drain when opening the \
 editor or browser.
 May not resume the drain automatically when closing it.''')
+        tab.check_box('startEmpty', 'Default initial life is 0',
+                      'Life will begin at 0 instead of full. Also affects Recover.')
         tab.label('<b>Special action behavior</b>')
         tab.combo_box('behavUndo', 'Delete', BEHAVIORS, '''How should the \
 program behave when deleting a card/note?''')
@@ -317,6 +320,7 @@ Invalid shortcuts, or already used shortcuts won't work.'''
         widget.enableAddon.set_value(conf['enable'])
         widget.stopOnAnswer.set_value(conf['stopOnAnswer'])
         widget.stopOnLostFocus.set_value(conf['stopOnLostFocus'])
+        widget.startEmpty.set_value(conf['startEmpty'])
         widget.behavUndo.set_value(conf['behavUndo'])
         widget.behavBury.set_value(conf['behavBury'])
         widget.behavSuspend.set_value(conf['behavSuspend'])


### PR DESCRIPTION
Resolves #109 

Adds a new global option that makes the initial life be 0 instead of full, also affecting the Recover button.