### PR TITLE
Fix crash on anki v23.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ meta.json
 
 # Dist files
 dist/
+
+# Virtual environment
+.venv/

--- a/src/database.py
+++ b/src/database.py
@@ -1,12 +1,15 @@
 # Copyright (c) Yutsuten <https://github.com/Yutsuten>. Licensed under AGPL-3.0.
 # See the LICENCE file in the repository root for full licence text.
 
-from typing import Any, ClassVar
+from __future__ import annotations
 
-from aqt.main import AnkiQt
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from .defaults import DEFAULTS
 from .exceptions import GetCollectionError, LoadConfigurationError
+
+if TYPE_CHECKING:
+    from aqt.main import AnkiQt
 
 
 class GlobalConf:

--- a/src/deck_manager.py
+++ b/src/deck_manager.py
@@ -1,16 +1,21 @@
 # Copyright (c) Yutsuten <https://github.com/Yutsuten>. Licensed under AGPL-3.0.
 # See the LICENCE file in the repository root for full licence text.
 
-from typing import Any, Literal, Optional, Union
+from __future__ import annotations
 
-from anki.consts import CardType
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+
 from anki.hooks import runHook
-from aqt.main import AnkiQt, MainWindowState
 
-from .database import DeckConf, GlobalConf
 from .decorators import must_have_active_deck
 from .defaults import BEHAVIORS
 from .progress_bar import ProgressBar
+
+if TYPE_CHECKING:
+    from anki.consts import CardType
+    from aqt.main import AnkiQt, MainWindowState
+
+    from .database import DeckConf, GlobalConf
 
 
 class DeckManager:
@@ -177,7 +182,7 @@ class DeckManager:
         bar_info['currentValue'] = history[bar_info['currentReview']]
         self._progress_bar.set_current_value(bar_info['currentValue'])
 
-    def _update_life(self, bar_info: dict[str, Any], difference: Union[int, float]) -> None:
+    def _update_life(self, bar_info: dict[str, Any], difference: float) -> None:
         """Apply recover/damage/drain.
 
         Args:

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -1,6 +1,8 @@
 # Copyright (c) Yutsuten <https://github.com/Yutsuten>. Licensed under AGPL-3.0.
 # See the LICENCE file in the repository root for full licence text.
 
+from __future__ import annotations
+
 from typing import Any, Callable
 
 from .exceptions import NoDeckSelectedError

--- a/src/lifedrain.py
+++ b/src/lifedrain.py
@@ -1,15 +1,18 @@
 # Copyright (c) Yutsuten <https://github.com/Yutsuten>. Licensed under AGPL-3.0.
 # See the LICENCE file in the repository root for full licence text.
 
-from typing import Any, Callable
+from __future__ import annotations
 
-from anki.cards import Card
-from aqt.main import AnkiQt, MainWindowState
+from typing import TYPE_CHECKING, Any, Callable, Union
 
 from . import settings
 from .database import DeckConf, GlobalConf
 from .deck_manager import DeckManager
 from .decorators import must_be_enabled
+
+if TYPE_CHECKING:
+    from anki.cards import Card
+    from aqt.main import AnkiQt, MainWindowState
 
 
 class Lifedrain:
@@ -170,10 +173,11 @@ class Lifedrain:
         self.status['reviewed'] = True
 
     @must_be_enabled
-    def _toggle_drain(self, config: dict[str, Any], enable=None) -> None:  # noqa: ARG
+    def _toggle_drain(self, config: dict[str, Any], enable: Union[bool, None]=None) -> None:  # noqa: ARG002
         """Toggles the life drain.
 
         Args:
+            config: Global configuration dictionary.
             enable: Optional. Enables the drain if True.
         """
         if self._timer.isActive() and enable is not True:

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,8 @@
 # Copyright (c) Yutsuten <https://github.com/Yutsuten>. Licensed under AGPL-3.0.
 # See the LICENCE file in the repository root for full licence text.
 
+from __future__ import annotations
+
 from typing import Any, Callable
 
 from anki import hooks
@@ -39,7 +41,7 @@ def setup_shortcuts(lifedrain: Lifedrain) -> None:
         elif state == 'overview':
             lifedrain.overview_shortcuts(shortcuts)
 
-    gui_hooks.collection_did_load.append(lambda col: lifedrain.update_global_shortcuts())  # noqa: ARG
+    gui_hooks.collection_did_load.append(lambda col: lifedrain.update_global_shortcuts())  # noqa: ARG005
     gui_hooks.state_shortcuts_will_change.append(state_shortcuts)
 
 
@@ -47,7 +49,7 @@ def setup_state_change(lifedrain: Lifedrain) -> None:
     """Set hooks triggered when changing state."""
     gui_hooks.state_will_change.append(lambda *args: lifedrain.screen_change(args[0]))
     gui_hooks.state_did_reset.append(
-        lambda *args: lifedrain.status.update({'reviewed': False}))  # noqa: ARG
+        lambda *args: lifedrain.status.update({'reviewed': False}))  # noqa: ARG005
 
 
 def setup_deck_browser(lifedrain: Lifedrain) -> None:
@@ -57,7 +59,7 @@ def setup_deck_browser(lifedrain: Lifedrain) -> None:
         menu.insertAction(menu.actions()[2], action)
         qt.qconnect(
             action.triggered,
-            lambda b: action_deck_settings(DeckId(did))  # noqa: ARG
+            lambda b: action_deck_settings(DeckId(did)),  # noqa: ARG005
         )
 
     def action_deck_settings(did: DeckId) -> None:
@@ -94,32 +96,32 @@ def setup_review(lifedrain: Lifedrain) -> None:
     """Set hooks triggered while reviewing."""
     gui_hooks.reviewer_did_show_question.append(lifedrain.show_question)
     gui_hooks.reviewer_did_show_answer.append(
-        lambda card: lifedrain.show_answer())  # noqa: ARG
+        lambda card: lifedrain.show_answer())  # noqa: ARG005
     gui_hooks.reviewer_did_answer_card.append(
         lambda *args: lifedrain.status.update({'review_response': args[2]}))
     if hasattr(gui_hooks, 'review_did_undo'):
         gui_hooks.review_did_undo.append(
-            lambda card_id: lifedrain.status.update({'action': 'undo'}))  # noqa: ARG
+            lambda card_id: lifedrain.status.update({'action': 'undo'}))  # noqa: ARG005
     gui_hooks.state_did_undo.append(
-        lambda out: lifedrain.status.update({'action': 'undo'}))  # noqa: ARG
+        lambda out: lifedrain.status.update({'action': 'undo'}))  # noqa: ARG005
 
     gui_hooks.browser_will_show.append(
-        lambda browser: lifedrain.opened_window())  # noqa: ARG
+        lambda browser: lifedrain.opened_window())  # noqa: ARG005
     gui_hooks.editor_did_init.append(
-        lambda editor: lifedrain.opened_window())  # noqa: ARG
+        lambda editor: lifedrain.opened_window())  # noqa: ARG005
     gui_hooks.deck_options_did_load.append(
-        lambda deck_options: lifedrain.opened_window())  # noqa: ARG
+        lambda deck_options: lifedrain.opened_window())  # noqa: ARG005
     gui_hooks.filtered_deck_dialog_did_load_deck.append(
-        lambda *args: lifedrain.opened_window())  # noqa: ARG
+        lambda *args: lifedrain.opened_window())  # noqa: ARG005
 
     # Action on cards
     hooks.notes_will_be_deleted.append(
-        lambda *args: lifedrain.status.update({'action': 'delete'}))  # noqa: ARG
+        lambda *args: lifedrain.status.update({'action': 'delete'}))  # noqa: ARG005
     gui_hooks.reviewer_will_suspend_note.append(
-        lambda *args: lifedrain.status.update({'action': 'suspend'}))  # noqa: ARG
+        lambda *args: lifedrain.status.update({'action': 'suspend'}))  # noqa: ARG005
     gui_hooks.reviewer_will_suspend_card.append(
-        lambda *args: lifedrain.status.update({'action': 'suspend'}))  # noqa: ARG
+        lambda *args: lifedrain.status.update({'action': 'suspend'}))  # noqa: ARG005
     gui_hooks.reviewer_will_bury_note.append(
-        lambda *args: lifedrain.status.update({'action': 'bury'}))  # noqa: ARG
+        lambda *args: lifedrain.status.update({'action': 'bury'}))  # noqa: ARG005
     gui_hooks.reviewer_will_bury_card.append(
-        lambda *args: lifedrain.status.update({'action': 'bury'}))  # noqa: ARG
+        lambda *args: lifedrain.status.update({'action': 'bury'}))  # noqa: ARG005

--- a/src/main.py
+++ b/src/main.py
@@ -97,8 +97,9 @@ def setup_review(lifedrain: Lifedrain) -> None:
         lambda card: lifedrain.show_answer())  # noqa: ARG
     gui_hooks.reviewer_did_answer_card.append(
         lambda *args: lifedrain.status.update({'review_response': args[2]}))
-    gui_hooks.review_did_undo.append(
-        lambda card_id: lifedrain.status.update({'action': 'undo'}))  # noqa: ARG
+    if hasattr(gui_hooks, 'review_did_undo'):
+        gui_hooks.review_did_undo.append(
+            lambda card_id: lifedrain.status.update({'action': 'undo'}))  # noqa: ARG
     gui_hooks.state_did_undo.append(
         lambda out: lifedrain.status.update({'action': 'undo'}))  # noqa: ARG
 

--- a/src/progress_bar.py
+++ b/src/progress_bar.py
@@ -1,11 +1,14 @@
 # Copyright (c) Yutsuten <https://github.com/Yutsuten>. Licensed under AGPL-3.0.
 # See the LICENCE file in the repository root for full licence text.
 
-from typing import Any, Literal, Union
+from __future__ import annotations
 
-from aqt.main import AnkiQt
+from typing import TYPE_CHECKING, Any, Literal, Union
 
 from .defaults import POSITION_OPTIONS, STYLE_OPTIONS, TEXT_FORMAT
+
+if TYPE_CHECKING:
+    from aqt.main import AnkiQt
 
 
 class ProgressBar:
@@ -128,7 +131,7 @@ class ProgressBar:
 
         existing_widgets = [
             widget for widget in self._mw.findChildren(self._qt.QDockWidget)
-            if self._mw.dockWidgetArea(widget) == dock_area  # pyright: ignore [reportGeneralTypeIssues] # noqa: E501
+            if self._mw.dockWidgetArea(widget) == dock_area  # pyright: ignore [reportGeneralTypeIssues]
         ]
         if not existing_widgets:
             self._mw.addDockWidget(dock_area, self._dock['widget'])

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,15 +1,19 @@
 # Copyright (c) Yutsuten <https://github.com/Yutsuten>. Licensed under AGPL-3.0.
 # See the LICENCE file in the repository root for full licence text.
 
+from __future__ import annotations
+
 from operator import itemgetter
-from typing import Any, Iterator, Optional, Union
+from typing import TYPE_CHECKING, Any, Iterator, Optional, Union
 
-from aqt.main import AnkiQt
-
-from .database import DeckConf, GlobalConf
-from .deck_manager import DeckManager
 from .defaults import BEHAVIORS, DEFAULTS, POSITION_OPTIONS, STYLE_OPTIONS, TEXT_FORMAT
 from .version import VERSION
+
+if TYPE_CHECKING:
+    from aqt.main import AnkiQt
+
+    from .database import DeckConf, GlobalConf
+    from .deck_manager import DeckManager
 
 
 class Form:
@@ -512,7 +516,7 @@ def deck_settings(aqt: Any, mw: AnkiQt, config: DeckConf, global_config: GlobalC
     dialog.exec()
 
 
-def _deck_basic_tab(aqt: Any, conf: dict[str, Any], life: Union[int, float]) -> Any:
+def _deck_basic_tab(aqt: Any, conf: dict[str, Any], life: float) -> Any:
 
     def generate_form() -> Any:
         tab = Form(aqt)


### PR DESCRIPTION
Fixes #167

`review_did_undo` hook was removed in v23.10.

[23.10beta6 changelog](https://github.com/ankitects/anki/releases/tag/23.10beta6)

> Remove legacy v1/v2 code by abdnh in https://github.com/ankitects/anki/pull/2727. This may also cause errors in some add-ons if they were referencing hooks that only applied to v1/v2.