### PR TITLE
Allow to full recover slowly

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -61,7 +61,7 @@ class GlobalConf:
 class DeckConf:
     """Manages Life Drain's deck configuration."""
     FIELDS: ClassVar[set[str]] = {
-        'enable', 'maxLife', 'recover', 'damage', 'damageNew', 'damageLearning',
+        'enable', 'maxLife', 'recover', 'damage', 'damageNew', 'damageLearning', 'fullRecoverSpeed',
     }
 
     def __init__(self, mw: AnkiQt):

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -29,6 +29,7 @@ TEXT_FORMAT = [{
 DEFAULTS = {
     'maxLife': 120,
     'recover': 5,
+    'fullRecoverSpeed': 0,
     'damage': None,
     'damageNew': None,
     'damageLearning': None,

--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,6 @@ from typing import Any, Callable
 from anki import hooks
 from anki.decks import DeckId
 from aqt import gui_hooks, mw, qt
-from aqt.progress import ProgressManager
 
 from .defaults import DEFAULTS
 from .exceptions import GetCollectionError, GetMainWindowError
@@ -20,8 +19,7 @@ def main() -> None:
     if mw is None:
         raise GetMainWindowError
 
-    make_timer = ProgressManager(mw).timer
-    lifedrain = Lifedrain(make_timer, mw, qt)
+    lifedrain = Lifedrain(mw, qt)
 
     setup_shortcuts(lifedrain)
     setup_state_change(lifedrain)
@@ -82,7 +80,8 @@ def setup_overview(lifedrain: Lifedrain) -> None:
             if url == 'lifedrain':
                 lifedrain.deck_settings()
             elif url == 'recover':
-                lifedrain.deck_manager.recover()
+                lifedrain.deck_manager.recovering = True
+                lifedrain.toggle_drain()
             return link_handler(url=url)
 
         return custom_link_handler

--- a/src/settings.py
+++ b/src/settings.py
@@ -437,7 +437,7 @@ that is recovered after answering a card.''')
         tab.double_spin_box('fullRecoverInput', 'Full recover speed', [-10000, 10000], '''Amount \
 to recover each second when clicking the "Recover" button in the deck overview screen. Negative \
 values allowed.
-Use 0 for the default behaviour: instant recovery.
+Use 0 for the default behavior: instant recovery.
 The recover will stop once life reaches 0, maximum, or when leaving deck overview screen.''')
         tab.check_box('enableDamageInput', 'Enable damage',
                       "Enable the damage feature. It will be triggered when \
@@ -613,7 +613,7 @@ that is recovered after answering a card.''')
         tab.double_spin_box('fullRecoverInput', 'Full recover speed', [-10000, 10000], '''Amount \
 to recover each second when clicking the "Recover" button in the deck overview screen. Negative \
 values allowed.
-Use 0 for the default behaviour: instant recovery.
+Use 0 for the default behavior: instant recovery.
 The recover will stop once life reaches 0, maximum, or when leaving deck overview screen.''')
         tab.fill_space()
         return tab.widget

--- a/src/settings.py
+++ b/src/settings.py
@@ -267,6 +267,7 @@ def global_settings(aqt: Any, mw: AnkiQt, config: GlobalConf, deck_manager: Deck
             'shareDrain': deck_defaults_tab.shareDrain.get_value(),
             'maxLife': deck_defaults_tab.maxLifeInput.value(),
             'recover': deck_defaults_tab.recoverInput.value(),
+            'fullRecoverSpeed': deck_defaults_tab.fullRecoverInput.value(),
             'damage': damage,
             'damageNew': damage_new,
             'damageLearning': damage_learning,
@@ -433,6 +434,11 @@ def _global_deck_defaults(aqt: Any, conf: dict[str, Any]) -> Any:
 seconds for the life bar go from full to empty.''')
         tab.spin_box('recoverInput', 'Recover', [0, 1000], '''Time in seconds \
 that is recovered after answering a card.''')
+        tab.double_spin_box('fullRecoverInput', 'Full recover speed', [-10000, 10000], '''Amount \
+to recover each second when clicking the "Recover" button in the deck overview screen. Negative \
+values allowed.
+Use 0 for the default behaviour: instant recovery.
+The recover will stop once life reaches 0, maximum, or when leaving deck overview screen.''')
         tab.check_box('enableDamageInput', 'Enable damage',
                       "Enable the damage feature. It will be triggered when \
 answering with 'Again'.")
@@ -449,6 +455,7 @@ answering with 'Again'.")
         widget.shareDrain.set_value(conf['shareDrain'])
         widget.maxLifeInput.set_value(conf['maxLife'])
         widget.recoverInput.set_value(conf['recover'])
+        widget.fullRecoverInput.set_value(conf['fullRecoverSpeed'])
 
         def update_damageinput() -> None:
             damage_enabled = widget.enableDamageInput.isChecked()
@@ -538,6 +545,7 @@ def deck_settings(aqt: Any, mw: AnkiQt, config: DeckConf, global_config: GlobalC
             'enable': basic_tab.enable.isChecked(),
             'maxLife': basic_tab.maxLifeInput.value(),
             'recover': basic_tab.recoverInput.value(),
+            'fullRecoverSpeed': basic_tab.fullRecoverInput.value(),
             'damage': damage,
             'damageNew': damage_new,
             'damageLearning': damage_learning,
@@ -598,10 +606,15 @@ def _deck_basic_tab(aqt: Any, conf: dict[str, Any], life: float) -> Any:
                       'Enable/disable Life Drain for this deck.')
         tab.spin_box('maxLifeInput', 'Maximum life', [1, 10000], '''Time in \
 seconds for the life bar go from full to empty.''')
-        tab.spin_box('recoverInput', 'Recover', [0, 1000], '''Time in seconds \
+        tab.spin_box('recoverInput', 'Answer recover', [0, 1000], '''Time in seconds \
 that is recovered after answering a card.''')
         tab.double_spin_box('currentValueInput', 'Current life', [0, 10000],
                             'Current life, in seconds.')
+        tab.double_spin_box('fullRecoverInput', 'Full recover speed', [-10000, 10000], '''Amount \
+to recover each second when clicking the "Recover" button in the deck overview screen. Negative \
+values allowed.
+Use 0 for the default behaviour: instant recovery.
+The recover will stop once life reaches 0, maximum, or when leaving deck overview screen.''')
         tab.fill_space()
         return tab.widget
 
@@ -610,6 +623,7 @@ that is recovered after answering a card.''')
         widget.maxLifeInput.set_value(conf['maxLife'])
         widget.recoverInput.set_value(conf['recover'])
         widget.currentValueInput.set_value(life)
+        widget.fullRecoverInput.set_value(conf['fullRecoverSpeed'])
 
     tab = generate_form()
     load_data(tab, conf)


### PR DESCRIPTION
Resolves #113 

The last big feature I'll implement to Life Drain. This project is already way bigger than I originally intended.

Cool feature, but it required a lot of changes in the code. If something is going to break in the next release, probably it will be because of this change.

This PR added:

- `Full recover speed` to Deck Settings
  - 0 for default behavior: instant recover
  - Anything else: the amount to recover each second. Negative values allowed. 