### PR TITLE
Fix custom bar style, show only available styles

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -7,7 +7,6 @@ lint.ignore = [
   "D107",    # Missing docstring in `__init__`
   "ANN002",  # Missing type annotation for `*args`
   "ANN003",  # Missing type annotation for `**kwargs`
-  "ANN101",  # Missing type annotation for `self` in method
   "ANN204",  # Missing return type annotation for special method
   "ANN401",  # Disallow typing.Any (qt modules aren't discovered by pyright)
   "UP007",   # Use X | Y for type annotations (only available in python 3.10+)

--- a/src/deck_manager.py
+++ b/src/deck_manager.py
@@ -92,10 +92,10 @@ class DeckManager:
         bar_info['damageLearning'] = conf['damageLearning']
 
         if update_life:
-            current_value = conf.get('currentValue', conf['maxLife'])
-            if current_value > conf['maxLife']:
-                current_value = conf['maxLife']
-            bar_info['currentValue'] = current_value
+            bar_info['currentValue'] = min(
+                conf.get('currentValue', conf['maxLife']),
+                conf['maxLife'],
+            )
 
     @must_have_active_deck
     def life_timer(self, bar_info: dict[str, Any]) -> None:

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -3,10 +3,6 @@
 
 BEHAVIORS = ['Drain life', 'Do nothing', 'Recover life']
 POSITION_OPTIONS = ['Top', 'Bottom']
-STYLE_OPTIONS = [
-    'Default', 'Cde', 'Cleanlooks', 'Fusion', 'Gtk', 'Macintosh', 'Motif',
-    'Plastique', 'Windows', 'Windows Vista', 'Windows XP',
-]
 TEXT_FORMAT = [{
     'text': 'None',
 }, {
@@ -44,7 +40,7 @@ DEFAULTS = {
     'barBorderRadius': 0,
     'barText': 0,
     'barTextColor': '#000',
-    'barStyle': STYLE_OPTIONS.index('Default'),
+    'barStyle': 0,
     'stopOnAnswer': False,
     'stopOnLostFocus': True,
     'startEmpty': False,

--- a/src/progress_bar.py
+++ b/src/progress_bar.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING, Any, Literal
 
-from .defaults import POSITION_OPTIONS, STYLE_OPTIONS, TEXT_FORMAT
+from .defaults import POSITION_OPTIONS, TEXT_FORMAT
 
 if TYPE_CHECKING:
     from aqt.main import AnkiQt
@@ -185,20 +185,21 @@ class ProgressBar:
             return
 
         self._current_bar_color = bar_color
-        custom_style = STYLE_OPTIONS[options['customStyle']] \
-            .replace(' ', '').lower()
-        if custom_style != 'default':
+        if options['customStyle']:
+            available_styles = ['default', *self._qt.QStyleFactory.keys()]
+            custom_style = available_styles[options['customStyle']]
+
             qstyle = self._qt.QStyleFactory.create(custom_style)
             self._qprogressbar.setStyle(qstyle)
 
             palette = self._qt.QPalette()
             fg_color = self._qt.QColor(bar_color)
-            palette.setColor(self._qt.QPalette.Highlight, fg_color)
+            palette.setColor(self._qt.QPalette.ColorRole.Highlight, fg_color)
 
             if 'bgColor' in options:
                 bg_color = self._qt.QColor(options['bgColor'])
-                palette.setColor(self._qt.QPalette.Base, bg_color)
-                palette.setColor(self._qt.QPalette.Window, bg_color)
+                palette.setColor(self._qt.QPalette.ColorRole.Base, bg_color)
+                palette.setColor(self._qt.QPalette.ColorRole.Window, bg_color)
 
             self._qprogressbar.setPalette(palette)
 
@@ -207,6 +208,7 @@ class ProgressBar:
             self._qprogressbar.setStyleSheet(
                 f'QProgressBar {{ {bar_elem} }}')
         else:
+            # Default style
             bar_elem_dict = {
                 'text-align': 'center',
                 'border-radius': f'{options["borderRadius"]}px',

--- a/src/settings.py
+++ b/src/settings.py
@@ -381,7 +381,7 @@ def _global_bar_style_tab(aqt: Any, conf: dict[str, Any]) -> Any:
         tab.spin_box('borderRadiusInput', 'Border radius', [0, 20],
                      'Add a rounded border to the life bar.')
         tab.combo_box('styleList', 'Style', ['Default', *aqt.QStyleFactory.keys()], '''Style of \
-the life bar (not all options may work on your platform).''')
+the life bar.''')
         tab.color_select('fgColor', 'Bar color (default)',
                          "Color of the life bar's foreground.")
         tab.spin_box('thresholdWarn', 'Warn threshold (%)', [0, 99],

--- a/src/settings.py
+++ b/src/settings.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any, Iterator, Optional, Union
 
-from .defaults import BEHAVIORS, DEFAULTS, POSITION_OPTIONS, STYLE_OPTIONS, TEXT_FORMAT
+from .defaults import BEHAVIORS, DEFAULTS, POSITION_OPTIONS, TEXT_FORMAT
 from .version import VERSION
 
 if TYPE_CHECKING:
@@ -380,8 +380,8 @@ def _global_bar_style_tab(aqt: Any, conf: dict[str, Any]) -> Any:
                      'Height of the life bar.')
         tab.spin_box('borderRadiusInput', 'Border radius', [0, 20],
                      'Add a rounded border to the life bar.')
-        tab.combo_box('styleList', 'Style', STYLE_OPTIONS, '''Style of the \
-life bar (not all options may work on your platform).''')
+        tab.combo_box('styleList', 'Style', ['Default', *aqt.QStyleFactory.keys()], '''Style of \
+the life bar (not all options may work on your platform).''')
         tab.color_select('fgColor', 'Bar color (default)',
                          "Color of the life bar's foreground.")
         tab.spin_box('thresholdWarn', 'Warn threshold (%)', [0, 99],


### PR DESCRIPTION
Closes #183 

- Changing bar style would only work for Qt5, now it works for both Qt5 and Qt6
- Available styles was hard-coded, but now we get the available styles by using `QStyleFactory.keys()`