### PR TITLE
Use default bar style if custom style isn't found

### DIFF
--- a/src/progress_bar.py
+++ b/src/progress_bar.py
@@ -185,16 +185,14 @@ class ProgressBar:
             return
 
         self._current_bar_color = bar_color
-        if options['customStyle']:
-            available_styles = ['default', *self._qt.QStyleFactory.keys()]
-            custom_style = available_styles[options['customStyle']]
+        available_styles = self._qt.QStyleFactory.keys()
 
-            qstyle = self._qt.QStyleFactory.create(custom_style)
+        if options['customStyle'] and options['customStyle'] <= len(available_styles):
+            qstyle = self._qt.QStyleFactory.create(available_styles[options['customStyle'] - 1])
             self._qprogressbar.setStyle(qstyle)
 
             palette = self._qt.QPalette()
-            fg_color = self._qt.QColor(bar_color)
-            palette.setColor(self._qt.QPalette.ColorRole.Highlight, fg_color)
+            palette.setColor(self._qt.QPalette.ColorRole.Highlight, self._qt.QColor(bar_color))
 
             if 'bgColor' in options:
                 bg_color = self._qt.QColor(options['bgColor'])

--- a/src/settings.py
+++ b/src/settings.py
@@ -381,7 +381,7 @@ def _global_bar_style_tab(aqt: Any, conf: dict[str, Any]) -> Any:
         tab.spin_box('borderRadiusInput', 'Border radius', [0, 20],
                      'Add a rounded border to the life bar.')
         tab.combo_box('styleList', 'Style', ['Default', *aqt.QStyleFactory.keys()], '''Style of \
-the life bar.''')
+the life bar. Custom styles coloring may only work after a restart.''')
         tab.color_select('fgColor', 'Bar color (default)',
                          "Color of the life bar's foreground.")
         tab.spin_box('thresholdWarn', 'Warn threshold (%)', [0, 99],


### PR DESCRIPTION
We save only the index of the style (0 for default style)
If the number of custom styles change, it could cause a crash.