### PR TITLE
Make recover shortcut work in review mode

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -11,6 +11,7 @@ lint.ignore = [
   "ANN401",  # Disallow typing.Any (qt modules aren't discovered by pyright)
   "UP007",   # Use X | Y for type annotations (only available in python 3.10+)
   "UP035",   # Deprecated import
+  "UP045",   # Use X | None instead of Optional (only available in python 3.10+)
 ]
 
 [lint.pydocstyle]

--- a/src/deck_manager.py
+++ b/src/deck_manager.py
@@ -36,6 +36,7 @@ class DeckManager:
             deck_conf: An instance of DeckConf.
         """
         self.recovering: bool = False
+        self.drain: bool = False
         self.timer = ProgressManager(mw).timer(100, self.life_timer, repeat=True, parent=mw)
         self.timer.stop()
         self._progress_bar = ProgressBar(mw, qt)
@@ -48,9 +49,12 @@ class DeckManager:
     def update(self, state: MainWindowState) -> None:
         """Updates the current deck's life bar."""
         if state == 'deckBrowser':
+            self.recovering = False
+            self.timer.stop()
             self._cur_deck_id = None
             self._progress_bar.set_visible(visible=False)
         else:
+            self.timer.start()
             self._cur_deck_id = self._get_cur_deck_id()
             if self._cur_deck_id not in self._bar_info:
                 self._add_deck(self._cur_deck_id)
@@ -105,11 +109,8 @@ class DeckManager:
                 self.recover()
             else:
                 self._update_life(bar_info, bar_info['fullRecoverSpeed'] / 10)
-        else:
+        elif self.drain:
             self._update_life(bar_info, -0.1)  # Drain
-
-        if bar_info['currentValue'] in [0, bar_info['maxValue']]:
-            self.timer.stop()
 
     @must_have_active_deck
     def heal(self, bar_info: dict[str, Any], value:Optional[Union[int, float]]=None, *,
@@ -142,6 +143,7 @@ class DeckManager:
         bar_info['currentValue'] = life
         self._progress_bar.set_current_value(life)
         self._game_over = start_empty
+        self.recovering = False
 
     @must_have_active_deck
     def damage(self, bar_info: dict[str, Any], card_type: CardType) -> None:
@@ -212,6 +214,9 @@ class DeckManager:
         elif not self._game_over:
             self._game_over = True
             runHook('LifeDrain.gameOver')
+        if life >= bar_info['maxValue']:
+            self.recovering = False
+
 
     def _next(self, bar_info: dict[str, Any]) -> None:
         """Remembers the current life and advances to the next card.

--- a/src/deck_manager.py
+++ b/src/deck_manager.py
@@ -214,7 +214,7 @@ class DeckManager:
         elif not self._game_over:
             self._game_over = True
             runHook('LifeDrain.gameOver')
-        if life >= bar_info['maxValue']:
+        if life >= bar_info['maxValue'] or life <= 0:
             self.recovering = False
 
 

--- a/src/lifedrain.py
+++ b/src/lifedrain.py
@@ -179,7 +179,7 @@ class Lifedrain:
         self.status['reviewed'] = True
 
     @must_be_enabled
-    def toggle_drain(self, config: dict[str, Any], enable: Union[bool, None]=None) -> None:  # noqa: ARG002
+    def toggle_drain(self, config: dict[str, Any], enable: Union[bool, None]=None) -> None:  # noqa: ARG002, FBT001
         """Toggles the life drain.
 
         Args:

--- a/src/lifedrain.py
+++ b/src/lifedrain.py
@@ -50,7 +50,7 @@ class Lifedrain:
 
     def global_settings(self) -> None:
         """Opens a dialog with the Global Settings."""
-        drain_enabled = self.deck_manager.timer.isActive()
+        drain_enabled = self.deck_manager.drain
         self.toggle_drain(enable=False)
         settings.global_settings(
             aqt=self._qt,
@@ -69,7 +69,7 @@ class Lifedrain:
 
     def deck_settings(self) -> None:
         """Opens a dialog with the Deck Settings."""
-        drain_enabled = self.deck_manager.timer.isActive()
+        drain_enabled = self.deck_manager.drain
         self.toggle_drain(enable=False)
         settings.deck_settings(
             aqt=self._qt,
@@ -100,6 +100,12 @@ class Lifedrain:
             shortcuts.append((config['deckSettingsShortcut'], self.deck_settings))
         if config['enable'] and config['pauseShortcut']:
             shortcuts.append((config['pauseShortcut'], self.toggle_drain))
+        if config['enable'] and config['recoverShortcut']:
+
+            def start_recover() -> None:
+                self.deck_manager.recovering = True
+
+            shortcuts.append((config['recoverShortcut'], start_recover))
 
     def overview_shortcuts(self, shortcuts: list[tuple]) -> None:
         """Generates the overview screen shortcuts."""
@@ -109,7 +115,7 @@ class Lifedrain:
         if config['enable'] and config['recoverShortcut']:
             def start_recover() -> None:
                 self.deck_manager.recovering = True
-                self.toggle_drain()
+
             shortcuts.append((config['recoverShortcut'], start_recover))
 
     def screen_change(self, state: MainWindowState) -> None:
@@ -130,7 +136,7 @@ class Lifedrain:
         if state != 'review':
             self.toggle_drain(enable=False)
             self.status['prev_card'] = None
-        if state != 'overview':
+        if state not in ['overview', 'review']:
             self.deck_manager.recovering = False
         if state != 'deckBrowser' and self.status['reviewed']:
             self.deck_manager.answer(
@@ -180,8 +186,7 @@ class Lifedrain:
             config: Global configuration dictionary.
             enable: Optional. Enables the drain if True.
         """
-        is_active = self.deck_manager.timer.isActive()
-        if is_active and enable is not True:
-            self.deck_manager.timer.stop()
-        elif not is_active and enable is not False:
-            self.deck_manager.timer.start()
+        if enable is None:
+            self.deck_manager.drain = not self.deck_manager.drain
+        else:
+            self.deck_manager.drain = enable

--- a/src/main.py
+++ b/src/main.py
@@ -81,7 +81,6 @@ def setup_overview(lifedrain: Lifedrain) -> None:
                 lifedrain.deck_settings()
             elif url == 'recover':
                 lifedrain.deck_manager.recovering = True
-                lifedrain.toggle_drain()
             return link_handler(url=url)
 
         return custom_link_handler

--- a/src/main.py
+++ b/src/main.py
@@ -73,8 +73,9 @@ def setup_overview(lifedrain: Lifedrain) -> None:
     """Add a Life Drain button into the overview screen."""
 
     def bottom_bar_draw(link_handler: Callable[..., bool], links: list[list]) -> Callable:
-        links.append([DEFAULTS['deckSettingsShortcut'], 'lifedrain', 'Life Drain'])
-        links.append(['None', 'recover', 'Recover'])
+        config = lifedrain.config.get()
+        links.append([config.get('deckSettingsShortcut') or 'None', 'lifedrain', 'Life Drain'])
+        links.append([config.get('recoverShortcut') or 'None', 'recover', 'Recover'])
 
         def custom_link_handler(url: str) -> bool:
             if url == 'lifedrain':

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,6 @@ from anki import hooks
 from anki.decks import DeckId
 from aqt import gui_hooks, mw, qt
 
-from .defaults import DEFAULTS
 from .exceptions import GetCollectionError, GetMainWindowError
 from .lifedrain import Lifedrain
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -435,10 +435,10 @@ seconds for the life bar go from full to empty.''')
         tab.spin_box('recoverInput', 'Answer recover', [0, 1000], '''Time in seconds \
 that is recovered after answering a card.''')
         tab.double_spin_box('fullRecoverInput', 'Full recover speed', [-10000, 10000], '''Amount \
-to recover each second when clicking the "Recover" button in the deck overview screen. Negative \
-values allowed.
+to recover each second when clicking the "Recover" button in the deck overview screen or using the Recover shortcut \
+on the review screen or deck overview screen. Negative values allowed.
 Use 0 for the default behavior: instant recovery.
-The recover will stop once life reaches 0, maximum, or when leaving deck overview screen.''')
+The recover will stop once life reaches maximum.''')
         tab.check_box('enableDamageInput', 'Enable damage',
                       "Enable the damage feature. It will be triggered when \
 answering with 'Again'.")

--- a/src/settings.py
+++ b/src/settings.py
@@ -435,10 +435,10 @@ seconds for the life bar go from full to empty.''')
         tab.spin_box('recoverInput', 'Answer recover', [0, 1000], '''Time in seconds \
 that is recovered after answering a card.''')
         tab.double_spin_box('fullRecoverInput', 'Full recover speed', [-10000, 10000], '''Amount \
-to recover each second when clicking the "Recover" button in the deck overview screen or using the Recover shortcut \
-on the review screen or deck overview screen. Negative values allowed.
+to recover each second when clicking the "Recover" button in the deck overview screen or using \
+the Recover shortcut on the review screen or deck overview screen. Negative values allowed.
 Use 0 for the default behavior: instant recovery.
-The recover will stop once life reaches maximum.''')
+The recover will stop once life reaches 0, maximum, or if going back to deck browser screen.''')
         tab.check_box('enableDamageInput', 'Enable damage',
                       "Enable the damage feature. It will be triggered when \
 answering with 'Again'.")
@@ -611,10 +611,10 @@ that is recovered after answering a card.''')
         tab.double_spin_box('currentValueInput', 'Current life', [0, 10000],
                             'Current life, in seconds.')
         tab.double_spin_box('fullRecoverInput', 'Full recover speed', [-10000, 10000], '''Amount \
-to recover each second when clicking the "Recover" button in the deck overview screen. Negative \
-values allowed.
+to recover each second when clicking the "Recover" button in the deck overview screen or using \
+the Recover shortcut on the review screen or deck overview screen. Negative values allowed.
 Use 0 for the default behavior: instant recovery.
-The recover will stop once life reaches 0, maximum, or when leaving deck overview screen.''')
+The recover will stop once life reaches 0, maximum, or if going back to deck browser screen.''')
         tab.fill_space()
         return tab.widget
 


### PR DESCRIPTION
This adds the ability to use the recover shortcut in review mode.

This will respect the slow recover mode as well. When you press recover it will increase until it reaches full health (even if you switch between review and overview mode). To make the code easier to reason about (and hopefully less error prone with the new changes), I made the timer always run whenever there is a deck selected, using separate variables for drain and recover.